### PR TITLE
Add Netsons CI deploy for the docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,17 +1,13 @@
 name: Deploy Documentation
 
+# Auto-deploy is frozen during the trussphp.com cutover. The push trigger is
+# intentionally removed so merging the Netsons deploy work does not rebuild
+# Pages with root-absolute content links (correct for trussphp.com, wrong for
+# the /laravel-truss Pages subpath). GitHub Pages keeps serving the last
+# published build, so github.io stays live and working until trussphp.com is
+# verified. At cutover, replace this with a redirect to trussphp.com or remove
+# it. Manual runs remain possible via workflow_dispatch.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'website/**'
-      # The live demo bundles the shipped frontend (copied at build time), so a
-      # frontend change must redeploy the docs too.
-      - 'resources/js/**'
-      - 'resources/css/**'
-      - 'resources/fonts/**'
-      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-netsons.yml
+++ b/.github/workflows/deploy-netsons.yml
@@ -1,0 +1,129 @@
+name: Deploy to Netsons
+
+# Builds the Astro docs site for the root domain and deploys it to Netsons over
+# SSH with rsync. Manual-only for now (workflow_dispatch) so it runs alongside
+# the GitHub Pages deploy without cutting over. A push trigger is added later,
+# once trussphp.com is verified.
+#
+# Required repo Secrets: SSH_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_KNOWN_HOSTS,
+# and optionally SSH_PORT (defaults to 65100) and SSH_KEY_PASSPHRASE.
+# Required repo Variable: DEPLOY_PATH (docroot relative to the SSH home, e.g.
+# "trussphp.com"). Kept as a variable so the server path is not committed.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: netsons-deploy
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'website/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Build website for the root domain
+        working-directory: website
+        env:
+          SITE_URL: 'https://trussphp.com'
+          SITE_BASE: ''
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-dist
+          path: website/dist
+          retention-days: 7
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-dist
+          path: dist
+
+      - name: Setup SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          SSH_KEY_PASSPHRASE: ${{ secrets.SSH_KEY_PASSPHRASE }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${SSH_KNOWN_HOSTS}" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          if [ -n "${SSH_KEY_PASSPHRASE}" ]; then
+            cat > /tmp/askpass.sh <<'SCRIPT'
+          #!/bin/bash
+          echo "$SSH_KEY_PASSPHRASE"
+          SCRIPT
+            chmod +x /tmp/askpass.sh
+            SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh-add ~/.ssh/deploy_key
+          else
+            ssh-add ~/.ssh/deploy_key
+          fi
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+
+      - name: Diagnose SSH connectivity
+        continue-on-error: true
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_PORT: ${{ secrets.SSH_PORT || '65100' }}
+        run: |
+          echo "== DNS resolution =="
+          getent hosts "${SSH_HOST}" || true
+          echo "== TCP probe ${SSH_PORT} =="
+          if timeout 30 bash -c "exec 3<>/dev/tcp/${SSH_HOST}/${SSH_PORT}" 2>/dev/null; then
+            echo "TCP connect OK, port is open from this runner"
+          else
+            echo "TCP connect FAILED, port filtered/closed or host unreachable"
+          fi
+
+      - name: Deploy via rsync
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_PORT: ${{ secrets.SSH_PORT || '65100' }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
+        run: |
+          if [ -z "${DEPLOY_PATH}" ]; then
+            echo "::error::DEPLOY_PATH repo variable is not set"
+            exit 1
+          fi
+          # Mirror dist/ into the docroot. Exclude cPanel-managed paths so a
+          # --delete never wipes them:
+          #   .well-known -> AutoSSL HTTP validation (breaking it stops renewals)
+          #   cgi-bin, .htaccess -> cPanel defaults for the addon domain
+          rsync -az --delete \
+            --exclude '.well-known/' \
+            --exclude 'cgi-bin/' \
+            --exclude '.htaccess' \
+            -e "ssh -p ${SSH_PORT} -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3" \
+            dist/ "${SSH_USER}@${SSH_HOST}:~/${DEPLOY_PATH}/"
+
+      - name: Verify site responds
+        continue-on-error: true
+        run: |
+          echo "== HTTPS check for trussphp.com =="
+          curl -sSI -m 20 https://trussphp.com | head -8 || true

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,9 +1,17 @@
 import { defineConfig } from 'astro/config'
 import starlight from '@astrojs/starlight'
 
+// Build target is env-driven so the same source builds for two hosts:
+//   - GitHub Pages (default): albertoarena.github.io/laravel-truss
+//   - Netsons root domain:    trussphp.com (SITE_URL set, SITE_BASE empty)
+// SITE_BASE uses ?? so an explicit empty string ('') means "root, no subpath".
+const SITE = process.env.SITE_URL || 'https://albertoarena.github.io'
+const BASE = process.env.SITE_BASE ?? '/laravel-truss'
+const COVER = `${SITE}${BASE}/cover-light.png`
+
 export default defineConfig({
-  site: 'https://albertoarena.github.io',
-  base: '/laravel-truss',
+  site: SITE,
+  base: BASE || undefined,
   integrations: [
     starlight({
       title: 'Laravel Truss',
@@ -14,11 +22,11 @@ export default defineConfig({
       },
       favicon: '/favicon.svg',
       head: [
-        { tag: 'meta', attrs: { property: 'og:image', content: 'https://albertoarena.github.io/laravel-truss/cover-light.png' } },
+        { tag: 'meta', attrs: { property: 'og:image', content: COVER } },
         { tag: 'meta', attrs: { property: 'og:image:width', content: '1200' } },
         { tag: 'meta', attrs: { property: 'og:image:height', content: '630' } },
         { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary_large_image' } },
-        { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://albertoarena.github.io/laravel-truss/cover-light.png' } },
+        { tag: 'meta', attrs: { name: 'twitter:image', content: COVER } },
       ],
       social: {
         github: 'https://github.com/albertoarena/laravel-truss',

--- a/website/src/content/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/getting-started/installation.mdx
@@ -25,7 +25,7 @@ A `--dev` install is excluded from `composer install --no-dev` builds, which is 
 composer require albertoarena/laravel-truss
 ```
 
-Then enable and authorize it as described in [Authorization](/laravel-truss/guides/authorization/).
+Then enable and authorize it as described in [Authorization](/guides/authorization/).
 :::
 
 ## Publish the config (optional)
@@ -36,7 +36,7 @@ To customise Truss, publish its configuration file to `config/truss.php`:
 php artisan vendor:publish --tag=truss-config
 ```
 
-Every option is documented inline and has a sensible default. See the [Configuration reference](/laravel-truss/reference/configuration/).
+Every option is documented inline and has a sensible default. See the [Configuration reference](/reference/configuration/).
 
 ## That is it
 
@@ -46,7 +46,7 @@ By default Truss is enabled in the `local` environment only. Start your app and 
 /truss
 ```
 
-You should see your schema as an ER diagram. Head to the [Quick start](/laravel-truss/getting-started/quick-start/) for a tour of the interface, or [Authorization](/laravel-truss/guides/authorization/) to run it safely in a non-local environment.
+You should see your schema as an ER diagram. Head to the [Quick start](/getting-started/quick-start/) for a tour of the interface, or [Authorization](/guides/authorization/) to run it safely in a non-local environment.
 
 :::note
 Truss reads the **live** database connection, so make sure your app's database is migrated and there is a schema to draw. If no connection is reachable, Truss falls back to replaying your migrations on an in-memory SQLite database and shows a banner saying so.

--- a/website/src/content/docs/getting-started/quick-start.mdx
+++ b/website/src/content/docs/getting-started/quick-start.mdx
@@ -10,13 +10,13 @@ By default Truss is enabled in the `local` environment only. Start your app and 
 The frame below runs the real Truss frontend on a fictional sample schema, so you can try everything on this page without installing anything. Drag to pan, scroll or pinch to zoom, and click a table name to focus or export it.
 
 <iframe
-  src="/laravel-truss/demo/"
+  src="/demo/"
   title="Laravel Truss live demo"
   loading="lazy"
   style="width: 100%; height: 620px; border: 1px solid var(--sl-color-gray-5); border-radius: 8px; margin-top: 1rem;"
 ></iframe>
 
-[Open the demo in its own tab](/laravel-truss/demo/) for more room. It contains structure only, no real data (there is none).
+[Open the demo in its own tab](/demo/) for more room. It contains structure only, no real data (there is none).
 
 ## Moving around
 
@@ -72,5 +72,5 @@ If you have configured more than one visualizable connection, a connection switc
 
 ## Next steps
 
-- [Authorization](/laravel-truss/guides/authorization/): run Truss safely in staging or production.
-- [Configuration reference](/laravel-truss/reference/configuration/): every option and its default.
+- [Authorization](/guides/authorization/): run Truss safely in staging or production.
+- [Configuration reference](/reference/configuration/): every option and its default.

--- a/website/src/content/docs/guides/authorization.mdx
+++ b/website/src/content/docs/guides/authorization.mdx
@@ -6,7 +6,7 @@ description: Gate access to Truss so it is safe to run in production
 Truss is designed to be safe to install in production and gated there. Access is guarded by two independent layers, and **both** must pass.
 
 :::note
-Running Truss on a non-local server requires it to be installed as a regular dependency, not a dev one. A `--dev` install is stripped from `composer install --no-dev` deploys, so `/truss` would 404. See [Installation](/laravel-truss/getting-started/installation/).
+Running Truss on a non-local server requires it to be installed as a regular dependency, not a dev one. A `--dev` install is stripped from `composer install --no-dev` deploys, so `/truss` would 404. See [Installation](/getting-started/installation/).
 :::
 
 ## The two layers

--- a/website/src/content/docs/guides/focus-and-filter.mdx
+++ b/website/src/content/docs/guides/focus-and-filter.mdx
@@ -18,7 +18,7 @@ Pick a table in **Focus** to reduce the diagram to that table plus its foreign-k
 
 Focus and filter **compose**: focus operates on whatever the filter left in, so you can filter to a group of tables and then focus within it.
 
-You can also **click a table name** in the diagram to focus it directly, without using the Focus box. The same menu lets you export that table's structure; see [Exporting a table](/laravel-truss/getting-started/quick-start/#exporting-a-table).
+You can also **click a table name** in the diagram to focus it directly, without using the Focus box. The same menu lets you export that table's structure; see [Exporting a table](/getting-started/quick-start/#exporting-a-table).
 
 ## Shareable views
 
@@ -36,4 +36,4 @@ Above a configurable table count (`large_schema.warn_above`, default `60`), an u
 
 ## Excluded tables
 
-Framework and infrastructure tables (`migrations`, `sessions`, `cache`, `jobs`, and so on) are excluded by default via `excluded_tables`. Exclusions are applied **server-side**, so excluded tables never reach the browser at all. See the [Configuration reference](/laravel-truss/reference/configuration/).
+Framework and infrastructure tables (`migrations`, `sessions`, `cache`, `jobs`, and so on) are excluded by default via `excluded_tables`. Exclusions are applied **server-side**, so excluded tables never reach the browser at all. See the [Configuration reference](/reference/configuration/).

--- a/website/src/content/docs/help/troubleshooting.mdx
+++ b/website/src/content/docs/help/troubleshooting.mdx
@@ -8,12 +8,12 @@ description: Common issues and how to resolve them
 Two things can cause this, and both return 404 on purpose:
 
 1. **Truss is disabled.** It is enabled in `local` only by default. In any other environment, set `TRUSS_ENABLED=true`.
-2. **The `viewTruss` gate denied you.** In non-local environments the gate is consulted. Make sure your user is allowed, either via `TRUSS_ALLOWED_EMAILS` or your own gate definition, and that you are logged in. See the [Authorization guide](/laravel-truss/guides/authorization/).
+2. **The `viewTruss` gate denied you.** In non-local environments the gate is consulted. Make sure your user is allowed, either via `TRUSS_ALLOWED_EMAILS` or your own gate definition, and that you are logged in. See the [Authorization guide](/guides/authorization/).
 
 ## The page loads but the diagram is blank
 
 - Check the browser console and network tab. If an asset request (for example `truss.js`) failed, ensure requests can reach `/{prefix}/assets/...`.
-- Under a strict Content-Security-Policy, allow `script-src 'self'`, `style-src 'self' 'unsafe-inline'`, and `font-src 'self'`. Mermaid needs `'unsafe-inline'` in `style-src`. See [Configuration](/laravel-truss/reference/configuration/#content-security-policy).
+- Under a strict Content-Security-Policy, allow `script-src 'self'`, `style-src 'self' 'unsafe-inline'`, and `font-src 'self'`. Mermaid needs `'unsafe-inline'` in `style-src`. See [Configuration](/reference/configuration/#content-security-policy).
 - If you set `TRUSS_MERMAID_URL` to a CDN, make sure your CSP allows that host in `script-src`.
 
 ## A banner says the SQLite fallback was used

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -6,15 +6,15 @@ hero:
   tagline: See your database structure as a live, scrollable, zoomable ER diagram, right inside your app. Structure only, never row data.
   actions:
     - text: Get Started
-      link: /laravel-truss/getting-started/installation/
+      link: /getting-started/installation/
       icon: right-arrow
       variant: primary
     - text: Live demo
-      link: /laravel-truss/demo/
+      link: /demo/
       icon: rocket
       variant: secondary
     - text: Configuration
-      link: /laravel-truss/reference/configuration/
+      link: /reference/configuration/
       variant: minimal
     - text: View on GitHub
       link: https://github.com/albertoarena/laravel-truss
@@ -57,10 +57,10 @@ It reads **structure only**: tables, columns, keys, and indexes. Row contents ar
 
 <CardGrid>
   <Card title="Installation" icon="rocket">
-    [Install the package](/laravel-truss/getting-started/installation/), one Composer command, auto-discovered.
+    [Install the package](/getting-started/installation/), one Composer command, auto-discovered.
   </Card>
   <Card title="Authorization" icon="approve-check">
-    [Gate access safely](/laravel-truss/guides/authorization/) so Truss is production-safe.
+    [Gate access safely](/guides/authorization/) so Truss is production-safe.
   </Card>
 </CardGrid>
 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -33,7 +33,7 @@ Every key has a sensible default and, where relevant, an `env()` override.
 
 ### `enabled` and `middleware`
 
-These, together with the `viewTruss` gate, control access. See the [Authorization guide](/laravel-truss/guides/authorization/).
+These, together with the `viewTruss` gate, control access. See the [Authorization guide](/guides/authorization/).
 
 ### `connections`
 


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that builds the Astro docs site for the `trussphp.com` root domain and deploys it to Netsons over SSH with rsync, and makes the site build host-portable so the same source targets either host.

### Commits
- **refactor: make docs site build host-portable** — `astro.config.mjs` is now env-driven (`SITE_URL`/`SITE_BASE`); `og:image`/`twitter:image` derive from them. Internal content links had their hardcoded `/laravel-truss/` prefix stripped so they resolve at the site root. Defaults are unchanged, so a plain build still targets GitHub Pages.
- **ci: add Netsons deploy workflow** — `deploy-netsons.yml`, `workflow_dispatch` only for now. Builds with `SITE_URL=https://trussphp.com SITE_BASE=''`, then rsyncs `dist/` into the docroot. Excludes `.well-known`, `cgi-bin`, `.htaccess` from `--delete` so cPanel AutoSSL keeps working.
- **ci: freeze GitHub Pages auto-deploy during cutover** — `deploy-docs.yml` is made manual-only. GitHub Pages keeps serving the last published build, so `albertoarena.github.io/laravel-truss` stays live and working until `trussphp.com` is verified.

## Why the Pages freeze

Starlight base-prefixes its own nav but not inline markdown body links, so root-absolute body links cannot be simultaneously correct for the Pages subpath and the root domain. Rather than maintain relative links (discarded at cutover), the body links are now in their correct final form for the root domain, and the live Pages site is frozen (not rebuilt) so nothing breaks during the overlap.

## Test plan

1. Merge this PR (Pages is frozen, so github.io is unaffected).
2. Run **Deploy to Netsons** via `workflow_dispatch` on `main`.
3. Verify `https://trussphp.com` renders the real site (not the courtesy page): internal links, logo, favicon, demo, downloads, and that AutoSSL `.well-known` survived.
4. github.io stays canonical throughout.

## After verification (follow-up, not in this PR)

- Update references (README docs badge/link, `composer.json` `support.docs`, GitHub About) to `trussphp.com`.
- Add a redirect from the github.io path to `trussphp.com`.
- Add the `push: main` trigger to `deploy-netsons.yml`.
- Analytics + Google Search Console.

## Required repo config (already set)

- Secrets: `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, `SSH_KNOWN_HOSTS`, optional `SSH_PORT`/`SSH_KEY_PASSPHRASE`.
- Variable: `DEPLOY_PATH=trussphp.com`.