### PR TITLE
Add Cloudflare Web Analytics to the docs site

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -27,6 +27,17 @@ export default defineConfig({
         { tag: 'meta', attrs: { property: 'og:image:height', content: '630' } },
         { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary_large_image' } },
         { tag: 'meta', attrs: { name: 'twitter:image', content: COVER } },
+        // Cloudflare Web Analytics beacon (cookieless, no consent banner). The
+        // token is public, not a secret. Manual install because the domain is
+        // grey-cloud (DNS-only), so Cloudflare cannot auto-inject it.
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            src: 'https://static.cloudflareinsights.com/beacon.min.js',
+            'data-cf-beacon': '{"token": "7f6eaa0832eb43cc838db8d337590f11"}',
+          },
+        },
       ],
       social: {
         github: 'https://github.com/albertoarena/laravel-truss',


### PR DESCRIPTION
## What

Adds the Cloudflare Web Analytics beacon to the Starlight `head` in `website/astro.config.mjs`.

## Why this analytics choice

- **Cookieless, no personal data**, so no GDPR consent banner is needed (relevant for an EU-based maintainer and audience).
- Free and already part of the Cloudflare account managing the domain.
- Manual JS-snippet install because the domain is **grey-cloud (DNS-only)**, so Cloudflare cannot auto-inject the beacon. The token is public (rendered in page HTML), not a secret, so it lives directly in the committed config.

## Verification

- Local build (`SITE_URL=https://trussphp.com SITE_BASE=''`) succeeds and the beacon `<script>` + token are present in `dist/index.html`.
- It is the docs site's only third-party script; the site has no strict CSP (that rule governs the package assets, not the Starlight site), so no CSP change is needed.

## Deploy

Merge, then dispatch **Deploy to Netsons**. Data appears in the Cloudflare Web Analytics dashboard within minutes.