### PR TITLE
style: full Connections label and anchor the legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The dashboard connection switcher label now reads "Connections" instead of "Conn".
+- The legend overlay anchors to the dashboard container rather than the viewport, so it stays correctly placed when the dashboard is embedded below other page chrome (an iframe, or an embed).
+
 ## [1.4.1] - 2026-07-29
 
 ### Changed

--- a/resources/css/truss.css
+++ b/resources/css/truss.css
@@ -137,6 +137,12 @@ body {
     var(--bp-bg);
 }
 
+/* The app is the positioning context for its absolutely-positioned overlays
+   (the legend). Without this they anchor to the viewport and land over the
+   toolbar when the dashboard is embedded below other chrome (an iframe, or the
+   docs demo's site bar). */
+#truss-app { position: relative; }
+
 /* ---- toolbar ---------------------------------------------------------- */
 
 .truss-toolbar {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -57,7 +57,7 @@
 
             <div class="truss-utils">
                 <label class="truss-field truss-field--conn" hidden>
-                    <span class="truss-field-label">Conn</span>
+                    <span class="truss-field-label">Connections</span>
                     <select id="truss-connection"></select>
                 </label>
                 <button type="button" class="truss-util truss-util--more" id="truss-more-btn" title="More controls" aria-expanded="false">⋯</button>

--- a/tests/Feature/Http/IndexRouteTest.php
+++ b/tests/Feature/Http/IndexRouteTest.php
@@ -24,6 +24,16 @@ it('renders the toolbar brand as the lowercase truss wordmark', function () {
     expect($html)->toMatch('/<span class="truss-brand">[\s\S]*?<\/svg>\s*truss\s*<\/span>/');
 });
 
+it('labels the connection switcher "Connections"', function () {
+    config()->set('truss.enabled', true);
+    Gate::define('viewTruss', fn ($user = null) => true);
+
+    $html = $this->get('/truss')->assertOk()->getContent();
+
+    // The switcher label reads the full word, matching the docs site, not "Conn".
+    expect($html)->toContain('<span class="truss-field-label">Connections</span>');
+});
+
 it('hides the index page entirely when Truss is disabled', function () {
     config()->set('truss.enabled', false);
     Gate::define('viewTruss', fn ($user = null) => true);

--- a/tests/js/app-anchor.test.js
+++ b/tests/js/app-anchor.test.js
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const css = readFileSync(
+  fileURLToPath(new URL('../../resources/css/truss.css', import.meta.url)),
+  'utf8'
+);
+
+const appRule = css.match(/#truss-app\s*\{[^}]*\}/)?.[0] ?? '';
+
+// The legend and the other absolutely-positioned overlays anchor to #truss-app,
+// so it must establish a positioning context. Without one they fall back to the
+// viewport and land over the toolbar when the dashboard is embedded below other
+// chrome (e.g. an iframe or the docs demo's site bar).
+describe('#truss-app positioning context', () => {
+  it('is a positioned container', () => {
+    expect(appRule).toMatch(/position\s*:\s*relative/);
+  });
+});


### PR DESCRIPTION
Finishes the toolbar-polish batch (the sentence-case labels shipped in v1.4.1; these are the last two items).

## Changes

1. **Connection switcher label: "Conn" -> "Connections".** The full word matches the docs site and is clearer. `resources/views/index.blade.php`.
2. **Legend anchoring.** `#truss-app` gains `position: relative` so the legend and other absolutely-positioned overlays anchor to the dashboard container instead of the viewport. In the standalone dashboard the legend already sat correctly (the app is at the viewport top), but when the dashboard is embedded below other chrome (an iframe, or the docs demo's site bar) the legend fell onto the toolbar. This makes it robust for embedding. `resources/css/truss.css`.

## Tests (TDD, written failing first)

- Pest: `IndexRouteTest` asserts the rendered shell carries the `Connections` label.
- Vitest: `app-anchor.test.js` asserts `truss.css` positions `#truss-app`, mirroring the `canvas-css` / `label-casing` pattern.
- Full local suite green: Pest 99, Vitest 83, Pint pass, Playwright 34.

Visual/robustness only, no behaviour change. Changelog updated under `[Unreleased]`.

Note: the docs demo's own toolbar shell still shows "Conn"; I'll sync that (and the multi-connection caption) in the docs repo separately, since the demo HTML is maintained there.