### PR TITLE
docs: releases CTA and private-contact email

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,4 +32,4 @@ The PHP suite uses an in-memory SQLite database and Orchestra Testbench, so no e
 
 ## Reporting bugs
 
-Open an issue with a minimal reproduction. A failing test is the most helpful form a report can take. For security issues, please email arena.alberto@gmail.com instead of opening a public issue.
+Open an issue with a minimal reproduction. A failing test is the most helpful form a report can take. For security issues, please email me@albertoarena.it instead of opening a public issue.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Laravel Truss is a live database structure viewer. It scans your live schema and
 
 **[Try the live demo](https://trussphp.com/demo/)** to pan, zoom, focus, and export a sample schema in your browser, no install needed. See what has shipped and what is next on the **[roadmap](https://trussphp.com/roadmap/)**.
 
+> **Stay updated:** click **Watch > Custom > Releases** to hear about new features, or follow along in [Discussions](https://github.com/albertoarena/laravel-truss/discussions).
+
 ## Features
 
 - Live ER diagram of your database, rendered with Mermaid.
@@ -87,7 +89,7 @@ Truss keeps its schema snapshot in the cache, which is derived and disposable. T
 
 ## Security
 
-Truss exposes structure only and never queries row data. Access is protected by the fixed `viewTruss` gate. If you discover a security issue, please email arena.alberto@gmail.com rather than opening a public issue.
+Truss exposes structure only and never queries row data. Access is protected by the fixed `viewTruss` gate. If you discover a security issue, please email me@albertoarena.it rather than opening a public issue.
 
 ## Contributing
 


### PR DESCRIPTION
## What

- Add a one-line "Stay updated" callout to the README pointing readers to **Watch > Custom > Releases** and the new **Discussions** tab.
- Swap the public contact address in the README Security section and the CONTRIBUTING bug-reporting note from the personal Gmail to `me@albertoarena.it`.

## Why

- **CTA:** the repo has stars but effectively no watchers, so a release currently has no push channel. The callout converts stars into watchers over time, giving future launches (like the schema-diff announcement in Discussions) a real notification path.
- **Email:** spam has been harvested from these plaintext prose surfaces. Moving reader-facing contact to `me@albertoarena.it` keeps the personal address off scrapeable prose. The `composer.json` author email is intentionally left unchanged, since that is the maintainer's GitHub email.

Docs-only change, no code paths touched.