### PR TITLE
ci: bump checkout to v7 for the Node 24 runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## What

Move `actions/checkout` from `v4` to `v7` in `lint.yml` and `run-tests.yml`.

## Why

The runners warn that `checkout@v4` targets the deprecated Node 20 action runtime and is being forced onto Node 24. `v7` runs on Node 24 natively, clearing the warning. This is the only Node 20 surface in this repo: CI is PHP/Pest only, with no Node build step.

## Scope notes

- This changes only the action runtime, not PHP or Pest, so the test matrix is unaffected.
- `shivammathur/setup-php@v2` is left as-is: `v2` is still the current major and its runtime is updated within the major.
- The `resources/js` Vitest and `tests/e2e` Playwright suites are not run in CI, so nothing else here touches Node.

## Verification

The `lint` and `tests` workflows run on this branch. Merge once green.