### PR TITLE
fix: toolbar overflow and mobile legend placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The dashboard toolbar no longer overflows the viewport on a small desktop. With every control active (filter, focus, depth, type labels, and the export, changes, health, legend, and theme buttons) and long table names, the bar could grow wider than the window; because it is sticky it pinned only vertically, so a horizontal drag slid the whole header sideways and clipped the brand. The secondary controls (focus, depth, type labels) now fold into the more menu below 1024px, the focus and connection selects are width capped, and the search field can shrink, so the toolbar always fits.
+- On a phone the legend now opens as a top-right dropdown, matching the changes and health panels, instead of a full-width bottom sheet, so all the toolbar overlays behave consistently.
 
 ## [1.5.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The dashboard toolbar no longer overflows the viewport on a small desktop. With every control active (filter, focus, depth, type labels, and the export, changes, health, legend, and theme buttons) and long table names, the bar could grow wider than the window; because it is sticky it pinned only vertically, so a horizontal drag slid the whole header sideways and clipped the brand. The secondary controls (focus, depth, type labels) now fold into the more menu below 1024px, the focus and connection selects are width capped, and the search field can shrink, so the toolbar always fits.
+
 ## [1.5.0] - 2026-07-30
 
 ### Added

--- a/resources/css/truss.css
+++ b/resources/css/truss.css
@@ -164,7 +164,8 @@ body {
   display: inline-flex; align-items: center; gap: 7px; white-space: nowrap;
 }
 .truss-field[hidden] { display: none; }
-.truss-field--search input { width: 150px; }
+.truss-field--search { min-width: 0; } /* let the search field shrink under pressure */
+.truss-field--search input { width: 150px; min-width: 0; }
 .truss-field-label {
   font-family: var(--bp-mono); font-size: 11px; letter-spacing: .01em;
   color: var(--bp-muted);
@@ -177,6 +178,9 @@ body {
   background: var(--bp-field); border: 1px solid var(--bp-field-line); border-radius: 2px; padding: 6px 9px;
 }
 .truss-toolbar input[type="number"] { width: 52px; }
+/* Cap the selects so a long table name (focus) or connection name cannot grow
+   the bar without bound and push the rest of the toolbar off-screen. */
+.truss-toolbar select { max-width: 180px; }
 .truss-toolbar input:focus, .truss-toolbar select:focus {
   outline: none; border-color: var(--bp-ink);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--bp-ink) 22%, transparent);
@@ -527,6 +531,25 @@ body {
 
 /* ---- responsive ------------------------------------------------------- */
 
+/* Small desktop: fold the secondary controls (focus, depth, type labels) behind
+   the ⋯ button as a dropdown panel, so a fully-featured toolbar (every control
+   active, long table names) never overflows the viewport. The bar is sticky and
+   pins vertically only, so an overflow would otherwise let a horizontal drag
+   slide the whole header and clip the brand. The phone block below layers on
+   mark-only branding and a full-width search. */
+@media (max-width: 1024px) {
+  .truss-util--more { display: inline-flex; }
+
+  .truss-secondary {
+    display: none; position: absolute; top: 100%; right: 8px; margin-top: 6px;
+    flex-direction: column; align-items: flex-start; gap: 14px; padding: 14px 16px;
+    background: var(--bp-panel); border: 1px solid var(--bp-panel-line); border-radius: 4px;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, .18); z-index: 25;
+  }
+  .truss-secondary.is-open { display: flex; }
+  .truss-secondary .truss-field-label { display: inline; } /* labels back inside the panel */
+}
+
 /* Tablet: drop the field labels to reclaim horizontal room; inputs stay. */
 @media (max-width: 900px) {
   .truss-toolbar { gap: 12px; }
@@ -543,16 +566,7 @@ body {
   .truss-brand { font-size: 0; gap: 0; } /* mark only, hide the wordmark */
   .truss-field--search { flex: 1; min-width: 0; }
   .truss-field--search input { width: 100%; }
-  .truss-util--more { display: inline-flex; }
-
-  .truss-secondary {
-    display: none; position: absolute; top: 100%; right: 8px; margin-top: 6px;
-    flex-direction: column; align-items: flex-start; gap: 14px; padding: 14px 16px;
-    background: var(--bp-panel); border: 1px solid var(--bp-panel-line); border-radius: 4px;
-    box-shadow: 0 8px 28px rgba(0, 0, 0, .18); z-index: 25;
-  }
-  .truss-secondary.is-open { display: flex; }
-  .truss-secondary .truss-field-label { display: inline; } /* labels back inside the panel */
+  /* The ⋯ button and the secondary dropdown are already set up at <=1024px. */
 
   /* legend as a bottom sheet */
   .truss-legend {

--- a/resources/css/truss.css
+++ b/resources/css/truss.css
@@ -566,13 +566,9 @@ body {
   .truss-brand { font-size: 0; gap: 0; } /* mark only, hide the wordmark */
   .truss-field--search { flex: 1; min-width: 0; }
   .truss-field--search input { width: 100%; }
-  /* The ⋯ button and the secondary dropdown are already set up at <=1024px. */
-
-  /* legend as a bottom sheet */
-  .truss-legend {
-    top: auto; bottom: 0; left: 0; right: 0; width: auto;
-    border-radius: 10px 10px 0 0; border-bottom: none;
-  }
+  /* The ⋯ button and the secondary dropdown are already set up at <=1024px. The
+     legend stays a top-right dropdown here too, matching the changes and health
+     panels, rather than becoming a full-width bottom sheet. */
 
   .truss-footer { gap: 10px; font-size: 10px; }
   #truss-stat-updated { display: none; }

--- a/resources/css/truss.css
+++ b/resources/css/truss.css
@@ -556,7 +556,6 @@ body {
   .truss-secondary { gap: 12px; }
   .truss-field-label { display: none; }
   .truss-field--search input { width: 130px; }
-  .truss-legend { top: 58px; }
 }
 
 /* Phone: collapse the secondary controls behind the ⋯ button as a panel;

--- a/tests/e2e/toolbar.html
+++ b/tests/e2e/toolbar.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Truss toolbar layout harness</title>
+    <!-- The REAL shipped stylesheet, so this exercises the actual responsive
+         rules (unlike harness.html, which inlines only the interaction bits). -->
+    <link rel="stylesheet" href="/resources/css/truss.css">
+</head>
+<body>
+    <!-- The real toolbar structure from resources/views/index.blade.php, with the
+         diff and health buttons shown (not hidden) so this mirrors the worst
+         case: an app with every toolbar control active, which is where the bar
+         overflowed on a small desktop. The focus select carries a long option to
+         stand in for long table names, another driver of the overflow. -->
+    <div id="truss-app">
+        <div class="truss-toolbar">
+            <span class="truss-brand">
+                <svg class="truss-mark" width="20" height="20" viewBox="0 0 32 32" fill="none" stroke="currentColor" aria-hidden="true">
+                    <path d="M16 5 L27 26 H5 Z" stroke-width="1.7" stroke-linejoin="miter"/>
+                </svg>
+                truss
+            </span>
+
+            <label class="truss-field truss-field--search">
+                <span class="truss-field-label">Filter</span>
+                <input id="truss-search" type="search" placeholder="table name…">
+            </label>
+
+            <div class="truss-secondary" id="truss-more">
+                <label class="truss-field">
+                    <span class="truss-field-label">Focus</span>
+                    <select id="truss-focus">
+                        <option>none</option>
+                        <option>land_registry_entries_project_documents</option>
+                    </select>
+                </label>
+                <label class="truss-field">
+                    <span class="truss-field-label">Depth</span>
+                    <input id="truss-depth" type="number" min="0" step="1">
+                </label>
+                <label class="truss-field truss-field--check">
+                    <input id="truss-labels" type="checkbox"> <span class="truss-field-label">Laravel types</span>
+                </label>
+            </div>
+
+            <div class="truss-utils">
+                <label class="truss-field truss-field--conn" hidden>
+                    <span class="truss-field-label">Connections</span>
+                    <select id="truss-connection"></select>
+                </label>
+                <button type="button" class="truss-util truss-util--more" id="truss-more-btn" title="More controls" aria-expanded="false">⋯</button>
+                <button type="button" class="truss-util" id="truss-export-btn" title="Export">⤓</button>
+                <button type="button" class="truss-util" id="truss-diff-btn" title="Changes">⇄</button>
+                <button type="button" class="truss-util" id="truss-health-btn" title="Health">
+                    <svg class="truss-health-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12 h6 l2 5 2-10 2 5 h4"/></svg>
+                    <span class="truss-health-count" id="truss-health-count">7</span>
+                </button>
+                <button type="button" class="truss-util" id="truss-legend-btn" title="Legend">▤</button>
+                <button type="button" class="truss-util" id="truss-theme-btn" title="Theme">◐</button>
+            </div>
+        </div>
+
+        <main id="truss-viewport"><div id="truss-canvas"></div></main>
+    </div>
+</body>
+</html>

--- a/tests/e2e/toolbar.html
+++ b/tests/e2e/toolbar.html
@@ -64,15 +64,20 @@
 
         <main id="truss-viewport"><div id="truss-canvas"></div></main>
 
-        <!-- Legend shown (not hidden) so its resting position can be asserted. It
-             should sit top-right like the health/changes panels, not become a
-             full-width bottom sheet on mobile. -->
+        <!-- Legend and the changes panel shown (not hidden) so their resting
+             positions can be compared. The legend should sit top-right at the
+             same vertical offset as the other overlays, not become a full-width
+             bottom sheet or a few pixels higher. -->
         <div class="truss-legend" id="truss-legend">
             <div class="truss-legend-head">Legend</div>
             <dl class="truss-legend-list">
                 <dt>PK</dt><dd>Primary key</dd>
                 <dt>FK</dt><dd>Foreign key</dd>
             </dl>
+        </div>
+        <div class="truss-diff-panel" id="truss-diff-panel">
+            <div class="truss-diff-head">Changes since last migration</div>
+            <div class="truss-diff-body"></div>
         </div>
     </div>
 </body>

--- a/tests/e2e/toolbar.html
+++ b/tests/e2e/toolbar.html
@@ -63,6 +63,17 @@
         </div>
 
         <main id="truss-viewport"><div id="truss-canvas"></div></main>
+
+        <!-- Legend shown (not hidden) so its resting position can be asserted. It
+             should sit top-right like the health/changes panels, not become a
+             full-width bottom sheet on mobile. -->
+        <div class="truss-legend" id="truss-legend">
+            <div class="truss-legend-head">Legend</div>
+            <dl class="truss-legend-list">
+                <dt>PK</dt><dd>Primary key</dd>
+                <dt>FK</dt><dd>Foreign key</dd>
+            </dl>
+        </div>
     </div>
 </body>
 </html>

--- a/tests/e2e/toolbar.spec.js
+++ b/tests/e2e/toolbar.spec.js
@@ -42,3 +42,20 @@ test('narrow (640px): still no overflow, controls behind the more button', async
   expect(await overflowsHorizontally(page)).toBe(false);
   await expect(page.locator('#truss-more-btn')).toBeVisible();
 });
+
+test('mobile (430px): the legend is a top-anchored dropdown, not a bottom sheet', async ({ page }) => {
+  await page.setViewportSize({ width: 430, height: 900 });
+  await page.goto(URL);
+
+  const box = await page.locator('#truss-legend').evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return { top: r.top, left: r.left, right: r.right };
+  });
+
+  // Anchored just under the toolbar like the health/changes panels, not pinned
+  // to the bottom of the page.
+  expect(box.top).toBeLessThan(120);
+  // A right-hand dropdown panel, not a full-width bottom sheet.
+  expect(box.left).toBeGreaterThan(0);
+  expect(box.right).toBeLessThanOrEqual(430);
+});

--- a/tests/e2e/toolbar.spec.js
+++ b/tests/e2e/toolbar.spec.js
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+// Layout-only checks against the real stylesheet (tests/e2e/toolbar.html loads
+// resources/css/truss.css and the real toolbar structure with every control
+// active). Guards the pre-existing bug where, on a small desktop, the full
+// toolbar overflowed the viewport; since it is position:sticky (vertical only),
+// a horizontal drag then slid the whole header left and clipped the brand.
+
+const URL = '/tests/e2e/toolbar.html';
+
+const overflowsHorizontally = (page) =>
+  page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
+
+test('wide desktop: all controls inline, no more-menu, no overflow', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 800 });
+  await page.goto(URL);
+
+  expect(await overflowsHorizontally(page)).toBe(false);
+  await expect(page.locator('#truss-more-btn')).toBeHidden();
+  await expect(page.locator('#truss-more')).toBeVisible();
+});
+
+test('small desktop (920px, the reported glitch band): no horizontal overflow', async ({ page }) => {
+  await page.setViewportSize({ width: 920, height: 800 });
+  await page.goto(URL);
+
+  expect(await overflowsHorizontally(page)).toBe(false);
+
+  // The brand stays anchored at the left edge (never scrolled/clipped away).
+  const left = await page.locator('.truss-brand').evaluate((el) => el.getBoundingClientRect().left);
+  expect(left).toBeGreaterThanOrEqual(0);
+
+  // The secondary controls fold behind the more button so the bar fits.
+  await expect(page.locator('#truss-more-btn')).toBeVisible();
+  await expect(page.locator('#truss-more')).toBeHidden();
+});
+
+test('narrow (640px): still no overflow, controls behind the more button', async ({ page }) => {
+  await page.setViewportSize({ width: 640, height: 800 });
+  await page.goto(URL);
+
+  expect(await overflowsHorizontally(page)).toBe(false);
+  await expect(page.locator('#truss-more-btn')).toBeVisible();
+});

--- a/tests/e2e/toolbar.spec.js
+++ b/tests/e2e/toolbar.spec.js
@@ -43,7 +43,7 @@ test('narrow (640px): still no overflow, controls behind the more button', async
   await expect(page.locator('#truss-more-btn')).toBeVisible();
 });
 
-test('mobile (430px): the legend is a top-anchored dropdown, not a bottom sheet', async ({ page }) => {
+test('mobile (430px): the legend is a top-anchored dropdown aligned with the other overlays', async ({ page }) => {
   await page.setViewportSize({ width: 430, height: 900 });
   await page.goto(URL);
 
@@ -51,10 +51,13 @@ test('mobile (430px): the legend is a top-anchored dropdown, not a bottom sheet'
     const r = el.getBoundingClientRect();
     return { top: r.top, left: r.left, right: r.right };
   });
+  const panelTop = await page.locator('#truss-diff-panel').evaluate((el) => el.getBoundingClientRect().top);
 
-  // Anchored just under the toolbar like the health/changes panels, not pinned
-  // to the bottom of the page.
+  // Anchored just under the toolbar, not pinned to the bottom of the page.
   expect(box.top).toBeLessThan(120);
+  // At the same vertical offset as the other overlays (changes/health), not a
+  // few pixels higher.
+  expect(box.top).toBe(panelTop);
   // A right-hand dropdown panel, not a full-width bottom sheet.
   expect(box.left).toBeGreaterThan(0);
   expect(box.right).toBeLessThanOrEqual(430);


### PR DESCRIPTION
Two related, pre-existing responsive-toolbar fixes (branched off `main`, independent of the theming work).

## 1. Toolbar overflow on a small desktop

With every control active (filter, focus, depth, type labels, and the export / changes / health / legend / theme buttons) and long table names, the bar grew wider than the window. Because it is `position: sticky` (which pins only vertically), the overflow let a horizontal drag slide the whole header sideways and clip the brand.

**Why it showed in real apps but not the live demo:** the demo has fewer active buttons and shorter sample names, so its bar never reached the overflow width; the reported case was ~900-925px.

**Fix (`resources/css/truss.css`):**
1. Collapse the secondary group (focus, depth, type labels) into the `…` menu at **≤1024px** (previously ≤560px only), comfortably above the full toolbar's width so there is no overflow band.
2. Cap the selects (`max-width: 180px`) so a long table or connection name cannot grow the bar without bound.
3. Let the search field shrink (`min-width: 0`).

At ≥1025px the toolbar is unchanged.

## 2. Mobile legend placement

On a phone the legend was a full-width bottom sheet, while the changes and health panels stayed top-right dropdowns, so it looked misplaced and inconsistent. Dropping the bottom-sheet override makes the legend keep the same top-right dropdown placement as the other overlays at every width.

## Tests

New layout e2e fixture `tests/e2e/toolbar.html` loads the **real** stylesheet and the real toolbar + legend structure with every control active (unlike `harness.html`, which inlines only the interaction styles). `tests/e2e/toolbar.spec.js` asserts:
- no horizontal overflow at wide (1440px), small-desktop (920px, the reported band), and narrow (640px) widths, plus the collapse behaviour;
- at phone width (430px) the legend is anchored under the toolbar as a dropdown, not a bottom sheet.

Each was confirmed red first, then green after the fix. Full suite green: 63 Playwright (4 new + 59 existing) and 95 Vitest. No regressions: the other e2e specs use `harness.html`, which does not load `truss.css`.

## Note

Trade-off: on a ~1024px laptop the focus/depth controls now live behind the `…` menu. That is the safe, no-overflow choice; a lower breakpoint would keep them inline longer at the cost of margin.