### PR TITLE
fix: theme the whole diagram, not just the tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Theming now re-skins the whole diagram, not just the tables. A custom `truss.theme` palette previously left the relationship lines and labels, the background grid label backdrop, and (in dark mode) the odd table rows and input backgrounds on the shipped Blueprint colours, so a themed diagram showed blue lines and mismatched rows. The `background`, `surface`, and `muted` knobs now also drive those tokens (`edge-bg`; `row-odd` and `field`; `rel` and `edge`), so a few knob values re-skin the diagram completely.
+
 ## [1.6.0] - 2026-08-03
 
 ### Added

--- a/config/truss.php
+++ b/config/truss.php
@@ -181,11 +181,11 @@ return [
     | Colour knobs and what each paints:
     |   accent            primary accent: headings, PK badges, entity borders, focus ring
     |   accent-secondary  secondary accent
-    |   background        the canvas / page background
-    |   surface           panels and table bodies
+    |   background        the canvas / page background (and relationship-label backdrop)
+    |   surface           panels, table bodies, rows, and inputs
     |   surface-alt       row striping
     |   text              body and diagram text
-    |   muted             secondary text
+    |   muted             secondary text and the relationship lines / labels
     |   border            table, panel, and field lines
     |
     */

--- a/src/Theme/ThemeStylesheet.php
+++ b/src/Theme/ThemeStylesheet.php
@@ -32,11 +32,11 @@ class ThemeStylesheet
     private const KNOBS = [
         'accent' => ['ink', 'focus-border'],
         'accent-secondary' => ['cyan'],
-        'background' => ['bg'],
-        'surface' => ['panel', 'entity-bg'],
+        'background' => ['bg', 'edge-bg'],
+        'surface' => ['panel', 'entity-bg', 'row-odd', 'field'],
         'surface-alt' => ['row-even'],
         'text' => ['fg', 'entity-text'],
-        'muted' => ['muted'],
+        'muted' => ['muted', 'rel', 'edge'],
         'border' => ['entity-border', 'hair', 'panel-line', 'field-line'],
     ];
 

--- a/tests/Unit/Theme/ThemeStylesheetTest.php
+++ b/tests/Unit/Theme/ThemeStylesheetTest.php
@@ -34,11 +34,11 @@ it('covers every documented knob and only maps known ones', function () {
     $knobs = [
         'accent' => ['ink', 'focus-border'],
         'accent-secondary' => ['cyan'],
-        'background' => ['bg'],
-        'surface' => ['panel', 'entity-bg'],
+        'background' => ['bg', 'edge-bg'],
+        'surface' => ['panel', 'entity-bg', 'row-odd', 'field'],
         'surface-alt' => ['row-even'],
         'text' => ['fg', 'entity-text'],
-        'muted' => ['muted'],
+        'muted' => ['muted', 'rel', 'edge'],
         'border' => ['entity-border', 'hair', 'panel-line', 'field-line'],
     ];
 
@@ -48,6 +48,24 @@ it('covers every documented knob and only maps known ones', function () {
             expect($css)->toContain("--bp-{$token}: #abcdef;");
         }
     }
+});
+
+it('themes the diagram chrome, not just tables, so a custom palette leaves nothing at the default', function () {
+    // Regression guard: relationship lines/labels (rel, edge, edge-bg), odd rows,
+    // and inputs used to stay on the Blueprint default, so a custom theme rendered
+    // a half-themed diagram (blue lines and dark-mode rows on a warm palette).
+    $css = themeCss(['colors' => ['light' => [
+        'muted' => '#777777',       // drives rel + edge (relationship lines and labels)
+        'background' => '#eeeeee',  // drives edge-bg (label backdrop)
+        'surface' => '#ffffff',     // drives row-odd + field (odd rows, inputs)
+    ]]]);
+
+    foreach (['rel', 'edge'] as $line) {
+        expect($css)->toContain("--bp-{$line}: #777777;");
+    }
+    expect($css)->toContain('--bp-edge-bg: #eeeeee;')
+        ->and($css)->toContain('--bp-row-odd: #ffffff;')
+        ->and($css)->toContain('--bp-field: #ffffff;');
 });
 
 it('places dark overrides under the media query and the forced-dark selector', function () {


### PR DESCRIPTION
## What

A custom `truss.theme` palette (shipped in v1.6.0) only re-skinned the tables, panels, text, and accents. The diagram's connective chrome stayed on the Blueprint default, so a themed diagram looked half-done:

- **Relationship lines and labels** (`rel`, `edge`) stayed blue on every custom theme, light and dark.
- The **label backdrop** (`edge-bg`) stayed the default page colour.
- In **dark mode**, the **odd table rows** (`row-odd`) and **input backgrounds** (`field`) stayed Blueprint-blue.

Found while building the demo palette showcase: the demo mirrors `ThemeStylesheet`'s map exactly, and the blue relationship lines and dark-mode rows were plainly visible on the Ember and Contrast palettes.

## Fix

Extend the knob to token map so the existing knobs also drive the diagram chrome. No new knobs, no API change:

| Knob | Added tokens |
| --- | --- |
| `background` | `edge-bg` |
| `surface` | `row-odd`, `field` |
| `muted` | `rel`, `edge` |

A few knob values now re-skin the diagram completely.

## Tests

TDD. Updated the knob-coverage test and added a regression test asserting a custom palette leaves none of `rel` / `edge` / `edge-bg` / `row-odd` / `field` at the default. Full suite green: Pest 285, Pint clean (JS/Playwright unaffected).

## Notes

- Not yet themed, intentionally deferred: `grid` / `grid-strong` (translucent, would need a hex to rgba step) and `focus-bg` (only shows while focusing). Both are faint; a follow-up can derive them from `accent`.
- Status and diff colours remain intentionally fixed (they are signals, per the theming decision).
- Patch release: this ships as v1.6.1.