### PR TITLE
fix: derive the background grid from the accent colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Theming now re-skins the whole diagram, not just the tables. A custom `truss.theme` palette previously left the relationship lines and labels, the background grid label backdrop, and (in dark mode) the odd table rows and input backgrounds on the shipped Blueprint colours, so a themed diagram showed blue lines and mismatched rows. The `background`, `surface`, and `muted` knobs now also drive those tokens (`edge-bg`; `row-odd` and `field`; `rel` and `edge`), so a few knob values re-skin the diagram completely.
+- Theming now re-skins the whole diagram, not just the tables. A custom `truss.theme` palette previously left the relationship lines and labels, the label backdrop, the background grid, and (in dark mode) the odd table rows and input backgrounds on the shipped Blueprint colours, so a themed diagram showed blue lines and mismatched rows. The `background`, `surface`, and `muted` knobs now also drive the label, row, and input tokens, and the background grid is derived as a faint tint of the `accent` colour, so a few knob values re-skin the diagram completely.
 
 ## [1.6.0] - 2026-08-03
 

--- a/src/Theme/ThemeStylesheet.php
+++ b/src/Theme/ThemeStylesheet.php
@@ -119,7 +119,35 @@ class ThemeStylesheet
             }
         }
 
+        // The background grid is a translucent tint of the accent, so it follows
+        // a custom accent rather than staying on the shipped blue. This needs the
+        // colour channels, so it applies only when the accent is a hex value; an
+        // rgb()/hsl()/keyword accent leaves the grid on the default.
+        $rgb = isset($knobs['accent']) ? $this->hexToRgb($this->sanitizeColor($knobs['accent'])) : null;
+        if ($rgb !== null) {
+            $decls[] = "--bp-grid: rgba({$rgb}, 0.07);";
+            $decls[] = "--bp-grid-strong: rgba({$rgb}, 0.12);";
+        }
+
         return $decls;
+    }
+
+    /**
+     * The "r, g, b" channels of a hex colour, or null if it is not hex (a short
+     * or long hex, with or without an alpha byte, which is dropped).
+     */
+    private function hexToRgb(?string $value): ?string
+    {
+        if ($value === null || preg_match('/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i', $value) !== 1) {
+            return null;
+        }
+
+        $hex = ltrim($value, '#');
+        if (strlen($hex) <= 4) {
+            $hex = $hex[0].$hex[0].$hex[1].$hex[1].$hex[2].$hex[2];
+        }
+
+        return hexdec(substr($hex, 0, 2)).', '.hexdec(substr($hex, 2, 2)).', '.hexdec(substr($hex, 4, 2));
     }
 
     /**

--- a/tests/Unit/Theme/ThemeStylesheetTest.php
+++ b/tests/Unit/Theme/ThemeStylesheetTest.php
@@ -68,6 +68,29 @@ it('themes the diagram chrome, not just tables, so a custom palette leaves nothi
         ->and($css)->toContain('--bp-field: #ffffff;');
 });
 
+it('derives a faint background grid from the accent colour', function () {
+    // The grid is a translucent tint of the accent, so it follows a custom
+    // accent instead of staying on the shipped blue.
+    $css = themeCss(['colors' => ['light' => ['accent' => '#112233'], 'dark' => ['accent' => '#aabbcc']]]);
+
+    expect($css)->toContain('--bp-grid: rgba(17, 34, 51, 0.07);')
+        ->and($css)->toContain('--bp-grid-strong: rgba(17, 34, 51, 0.12);')
+        ->and($css)->toContain('--bp-grid: rgba(170, 187, 204, 0.07);');
+});
+
+it('accepts a short #rgb accent for the grid derivation', function () {
+    expect(themeCss(['colors' => ['light' => ['accent' => '#abc']]]))
+        ->toContain('--bp-grid: rgba(170, 187, 204, 0.07);');
+});
+
+it('skips the grid derivation when the accent is not a hex colour', function () {
+    // rgb()/hsl()/keyword accents are valid, but the grid tint needs channels.
+    $css = themeCss(['colors' => ['light' => ['accent' => 'rebeccapurple']]]);
+
+    expect($css)->toContain('--bp-ink: rebeccapurple;')
+        ->and($css)->not->toContain('--bp-grid:');
+});
+
 it('places dark overrides under the media query and the forced-dark selector', function () {
     $css = themeCss(['colors' => ['dark' => ['background' => '#0b1020']]]);
 


### PR DESCRIPTION
Follow-up to #23, completing the diagram theming.

## What

The faint background grid (`--bp-grid` / `--bp-grid-strong`) was the last piece still on the shipped Blueprint blue under a custom palette. It is a translucent tint of the accent, so it now follows a custom `accent`: derived as `rgba(<accent channels>, 0.07)` and `0.12`, the grid's usual opacities.

Because it needs the colour channels, this applies when `accent` is a hex value; an `rgb()` / `hsl()` / keyword accent leaves the grid on the default (a documented, graceful skip). No new knob, no API change.

## Tests

TDD. Added cases for the hex derivation (`#rrggbb` and short `#rgb`), the dark accent producing its own grid, and the non-hex skip. Full suite green: Pest 288, Pint clean.

## Result

With this and #23, a custom palette re-skins the entire diagram, tables, rows, inputs, relationship lines and labels, and the grid, with no token left on the default. Ships in v1.6.1.