### PR TITLE
ci: SHA-pin actions, add Dependabot and SECURITY.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # Keep the SHA-pinned workflow actions current. Dependabot rewrites both the
+  # SHA and the trailing version comment when a new release lands.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+
+  # Composer dependencies (runtime and dev). Minor and patch bumps are grouped
+  # into a single PR to keep the noise down; majors open on their own.
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      composer-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Client-side diagram tooling (Vitest, Playwright, the Mermaid generator).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/github-traffic-badge.yml
+++ b/.github/workflows/github-traffic-badge.yml
@@ -12,7 +12,7 @@ jobs:
   update-badge:
     runs-on: ubuntu-latest
     steps:
-      - uses: albertoarena/github-traffic-badge@v1
+      - uses: albertoarena/github-traffic-badge@56f6f3e0ed586f14440561758b197ca57a38f480 # v1.1.4
         with:
           token: ${{ secrets.TRAFFIC_TOKEN }}
           metric: views

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.3'
           coverage: none

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, intl, fileinfo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported versions
+
+The latest released `1.x` line receives security fixes.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security problems. Instead, email the maintainer at
+me@albertoarena.it with a description of the issue and a way to reproduce it. You can expect an
+acknowledgement within a few days, and a fix or mitigation plan once the report is confirmed.
+
+## Scope
+
+Truss exposes database structure only (tables, columns, indexes, foreign keys) and never queries or
+renders row data. Access is protected by the fixed `viewTruss` gate, which is consulted in every
+non-local environment and returns 404 on denial. Reports about structure leaking as data, the gate
+being bypassed, or the asset route serving unintended files are all in scope.


### PR DESCRIPTION
Closes the three security findings flagged by the Plumb PHP scorecard.

## Changes

- **SHA-pin every GitHub Actions reference.** `actions/checkout`, `shivammathur/setup-php` and `albertoarena/github-traffic-badge` are now pinned to full 40-character commit SHAs with a trailing version comment, so a tag can no longer be re-pointed at malicious code.
- **Add `.github/dependabot.yml`.** Weekly updates for `github-actions`, `composer` and `npm`, each with a seven-day cooldown. Dependabot rewrites both the SHA and its version comment when a new release lands, keeping the pins current.
- **Add `SECURITY.md`.** Documents a private disclosure channel (me@albertoarena.it) and the reporting scope.

No runtime code changes.