### PR TITLE
chore: point homepage at trussphp.com

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "mermaid",
         "introspection"
     ],
-    "homepage": "https://github.com/albertoarena/laravel-truss",
+    "homepage": "https://trussphp.com",
     "support": {
         "issues": "https://github.com/albertoarena/laravel-truss/issues",
         "source": "https://github.com/albertoarena/laravel-truss",


### PR DESCRIPTION
The top-level `homepage` field in composer.json pointed at the GitHub repository. Packagist and package directories read that field to build their "Homepage" link, so the ecosystem showed GitHub as the package's home rather than the owned domain.

Change `homepage` to `https://trussphp.com`, the canonical site. `support.source` and `support.issues` stay on GitHub (correct), and `support.docs` already points at trussphp.com. One line, nothing else touched.

Ships with the next tag, no separate deploy needed.