### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-10
+
 ### Added
 
 - Truss as AI context: the export now doubles as grounding context for a coding agent.


### PR DESCRIPTION
Cuts the v1.8.0 release. Moves the `[Unreleased]` changelog notes into a dated `## [1.8.0] - 2026-08-10` section; no code changes.

Release contents (already merged to main under Unreleased):
- Truss as AI context: annotations, `--compact`, `--focus`/`--depth`, the `llm` format, `truss.export.default_format`.
- The gated `GET {prefix}/export/{format}` route.
- The optional read-only, structure-only MCP server (`laravel/mcp`), with tools that advertise the read-only hint.
- The immutable `Truss` facade.
- composer.json `homepage` now points at trussphp.com.

After this merges: tag `v1.8.0` on the release commit, publish the GitHub release, then merge the three held docs PRs (#3, #4, #5) so trussphp.com redeploys and the demo picks up the v1.8.0 frontend.

Local suite green (365 passed, 2 skipped), Pint clean; CI green on the branch point.