### PR TITLE
Explain an empty diagram and offer a way out of the focus

### DIFF
--- a/resources/css/truss.css
+++ b/resources/css/truss.css
@@ -417,6 +417,13 @@ body {
   display: flex; align-items: center; gap: 9px;
 }
 .truss-banner::before { content: "◧"; opacity: .8; }
+/* the way out of an empty diagram, e.g. "Clear focus" */
+.truss-banner-action {
+  font: inherit; letter-spacing: inherit; color: inherit;
+  background: none; border: 0; border-bottom: 1px solid currentColor;
+  padding: 0; cursor: pointer; opacity: .85;
+}
+.truss-banner-action:hover { opacity: 1; }
 .truss-banner--info { background: var(--bp-info-bg); color: var(--bp-info-fg); }
 .truss-banner--warn { background: var(--bp-warn-bg); color: var(--bp-warn-fg); }
 .truss-banner--error { background: var(--bp-error-bg); color: var(--bp-error-fg); }

--- a/resources/js/selection.js
+++ b/resources/js/selection.js
@@ -21,6 +21,58 @@ export function filterTables(tables, query) {
 }
 
 /**
+ * The whole selection pipeline: filter first, then narrow to the focused
+ * neighbourhood. The two compose, so a filter inside a focus searches within
+ * that neighbourhood rather than replacing it.
+ *
+ * @param {Array} tables the full received set
+ * @param {{search?: string, focusRoot?: string, depth?: number}} [selection]
+ * @returns {Array} the subset to render
+ */
+export function selectTables(tables, { search = '', focusRoot = '', depth = 1 } = {}) {
+  const subset = filterTables(tables, search);
+
+  return focusRoot ? focusTables(subset, focusRoot, depth) : subset;
+}
+
+/**
+ * Why the diagram is empty, and whether clearing the focus would bring it back.
+ * Composing filter and focus is deliberate, but when the intersection is empty
+ * the diagram looks broken: the focus control sits away from the filter box, so
+ * by the time someone searches they have usually forgotten a focus is set. The
+ * notice names both, and only offers to clear the focus when doing so would
+ * actually show something.
+ *
+ * @param {Array} tables the full received set
+ * @param {{search?: string, focusRoot?: string, depth?: number}} [selection]
+ * @returns {?{message: string, clearFocus: boolean}} null while tables are showing
+ */
+export function emptySelectionNotice(tables, { search = '', focusRoot = '', depth = 1 } = {}) {
+  if (selectTables(tables, { search, focusRoot, depth }).length > 0) {
+    return null;
+  }
+
+  const query = String(search ?? '').trim();
+  const withoutFocus = query === '' ? tables : filterTables(tables, query);
+
+  if (focusRoot && withoutFocus.length > 0) {
+    return {
+      message: query === ''
+        ? `No tables match focus: ${focusRoot}.`
+        : `No tables match "${query}" within focus: ${focusRoot}.`,
+      clearFocus: true,
+    };
+  }
+
+  // Either nothing is scoped, or the filter alone already matches nothing, in
+  // which case dropping the focus would leave the diagram just as empty.
+  return {
+    message: query === '' ? 'No tables match the current filter or focus.' : `No tables match "${query}".`,
+    clearFocus: false,
+  };
+}
+
+/**
  * A table plus its foreign-key neighbours out to `depth` hops. Neighbours are
  * followed in both directions — a table's own FKs (children → parents) and any
  * table that references it (parents → children) — so the neighbourhood is the

--- a/resources/js/truss.js
+++ b/resources/js/truss.js
@@ -2,7 +2,7 @@
 // pure, unit-tested modules (selection, generator, viewport math). No build
 // step: native ES module; Mermaid is a global from a <script> tag.
 
-import { filterTables, focusTables } from './selection.js';
+import { selectTables, emptySelectionNotice } from './selection.js';
 import { generateErDiagram } from './mermaid-definition.js';
 import { clamp, fitTransform, zoomAtPoint, ZOOM_LIMITS } from './viewport.js';
 import { buildQuery, parseQuery } from './url-state.js';
@@ -98,12 +98,19 @@ mermaid.initialize({
 
 /* ---- selection -------------------------------------------------------- */
 
+function currentSelection() {
+  return { search: state.search, focusRoot: state.focusRoot, depth: state.depth };
+}
+
 function currentSubset() {
-  let subset = filterTables(state.tables, state.search);
-  if (state.focusRoot) {
-    subset = focusTables(subset, state.focusRoot, state.depth);
-  }
-  return subset;
+  return selectTables(state.tables, currentSelection());
+}
+
+/** Drop the focus but keep the filter, so the search the user just typed applies. */
+function clearFocus() {
+  state.focusRoot = '';
+  if (el.focus) el.focus.value = '';
+  render();
 }
 
 /* ---- pan / zoom ------------------------------------------------------- */
@@ -938,14 +945,25 @@ function toggleMore() {
 
 /* ---- rendering -------------------------------------------------------- */
 
-function banner(kind, text) {
+function banner(kind, text, action = null) {
   const node = document.createElement('div');
   node.className = `truss-banner truss-banner--${kind}`;
-  node.textContent = text;
+  node.append(document.createTextNode(text));
+
+  if (action) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'truss-banner-action';
+    button.textContent = action.label;
+    button.setAttribute(action.attribute, '');
+    button.addEventListener('click', action.onClick);
+    node.append(button);
+  }
+
   return node;
 }
 
-function renderBanners(subsetCount) {
+function renderBanners() {
   el.banners.replaceChildren();
   if (state.fallback) {
     el.banners.append(banner('warn',
@@ -956,8 +974,13 @@ function renderBanners(subsetCount) {
     el.banners.append(banner('info',
       `${state.tables.length} tables — large schema. Use the filter or focus a table to keep the diagram fast and legible.`));
   }
-  if (subsetCount === 0) {
-    el.banners.append(banner('info', 'No tables match the current filter or focus.'));
+  // When the diagram is empty, say which of the filter and the focus emptied it,
+  // and offer to drop the focus when that is what is hiding the match.
+  const notice = emptySelectionNotice(state.tables, currentSelection());
+  if (notice) {
+    el.banners.append(banner('info', notice.message, notice.clearFocus
+      ? { label: 'Clear focus', attribute: 'data-clear-focus', onClick: clearFocus }
+      : null));
   }
 }
 
@@ -976,7 +999,7 @@ function syncUrl() {
 async function render() {
   const subset = currentSubset();
   syncUrl();
-  renderBanners(subset.length);
+  renderBanners();
 
   if (subset.length === 0) {
     el.canvas.replaceChildren();

--- a/tests/e2e/truss.spec.js
+++ b/tests/e2e/truss.spec.js
@@ -66,6 +66,35 @@ test('focus mode reduces to a table and its FK neighbours', async ({ page }) => 
   await expect(canvas(page)).not.toContainText('roles');
 });
 
+test('searching outside the focused neighbourhood explains itself and offers a way out', async ({ page }) => {
+  // Issue #34: focus a table, search for one outside it, and the diagram empties
+  // with no hint that the focus is what is hiding the match.
+  await page.selectOption('#truss-focus', 'users');
+  await expect(canvas(page)).toContainText('role_user');
+
+  await page.fill('#truss-search', 'roles');
+
+  await expect(banners(page)).toContainText('No tables match "roles" within focus: users.');
+  await expect(canvas(page)).not.toContainText('roles');
+
+  await page.click('#truss-banners [data-clear-focus]');
+
+  await expect(canvas(page)).toContainText('roles');
+  await expect(banners(page)).not.toContainText('within focus');
+  await expect(page.locator('#truss-focus')).toHaveValue('');
+  expect(new URL(page.url()).searchParams.get('focus')).toBeNull();
+  // The filter the user typed survives clearing the focus.
+  await expect(page.locator('#truss-search')).toHaveValue('roles');
+});
+
+test('no way out is offered when the filter alone matches nothing', async ({ page }) => {
+  await page.selectOption('#truss-focus', 'users');
+  await page.fill('#truss-search', 'zzz');
+
+  await expect(banners(page)).toContainText('No tables match "zzz".');
+  await expect(page.locator('#truss-banners [data-clear-focus]')).toHaveCount(0);
+});
+
 test('focus centres the focused table in the viewport', async ({ page }) => {
   await expect(page.locator('#truss-canvas > svg')).toBeVisible();
   await page.selectOption('#truss-focus', 'users');

--- a/tests/js/empty-state.test.js
+++ b/tests/js/empty-state.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { selectTables, emptySelectionNotice } from '../../resources/js/selection.js';
+import { schema } from './fixtures.js';
+
+const names = (tables) => tables.map((t) => t.name).sort();
+
+describe('selectTables — the filter and focus pipeline', () => {
+  it('returns everything when neither filter nor focus is set', () => {
+    expect(names(selectTables(schema, {}))).toEqual(names(schema));
+  });
+
+  it('applies the filter alone', () => {
+    expect(names(selectTables(schema, { search: 'role' }))).toEqual(['role_user', 'roles']);
+  });
+
+  it('applies the focus alone', () => {
+    expect(names(selectTables(schema, { focusRoot: 'users', depth: 1 })))
+      .toEqual(['posts', 'role_user', 'users']);
+  });
+
+  it('intersects the two, which is what empties the diagram', () => {
+    // roles is outside the users neighbourhood at depth 1.
+    expect(selectTables(schema, { search: 'roles', focusRoot: 'users', depth: 1 })).toEqual([]);
+  });
+});
+
+describe('emptySelectionNotice — why the diagram is empty, and the way out', () => {
+  it('says nothing while tables are showing', () => {
+    expect(emptySelectionNotice(schema, {})).toBeNull();
+    expect(emptySelectionNotice(schema, { search: 'role' })).toBeNull();
+    expect(emptySelectionNotice(schema, { focusRoot: 'users', depth: 1 })).toBeNull();
+  });
+
+  it('names the filter and the focus, and offers to clear the focus', () => {
+    // The reported case: focus a table, then search for one outside it (issue #34).
+    expect(emptySelectionNotice(schema, { search: 'roles', focusRoot: 'users', depth: 1 })).toEqual({
+      message: 'No tables match "roles" within focus: users.',
+      clearFocus: true,
+    });
+  });
+
+  it('does not offer to clear the focus when the filter alone matches nothing', () => {
+    // Clearing the focus would still leave an empty diagram, so do not suggest it.
+    expect(emptySelectionNotice(schema, { search: 'zzz', focusRoot: 'users', depth: 1 })).toEqual({
+      message: 'No tables match "zzz".',
+      clearFocus: false,
+    });
+  });
+
+  it('offers to clear a focus that matches nothing on its own', () => {
+    // e.g. a deep link to a table that config excludes on this connection.
+    expect(emptySelectionNotice(schema, { focusRoot: 'gone', depth: 1 })).toEqual({
+      message: 'No tables match focus: gone.',
+      clearFocus: true,
+    });
+  });
+
+  it('reports a filter-only miss without mentioning focus', () => {
+    expect(emptySelectionNotice(schema, { search: 'zzz' })).toEqual({
+      message: 'No tables match "zzz".',
+      clearFocus: false,
+    });
+  });
+
+  it('falls back to the generic message when there is nothing to name', () => {
+    expect(emptySelectionNotice([], {})).toEqual({
+      message: 'No tables match the current filter or focus.',
+      clearFocus: false,
+    });
+    expect(emptySelectionNotice([], { focusRoot: 'users' })).toEqual({
+      message: 'No tables match the current filter or focus.',
+      clearFocus: false,
+    });
+  });
+
+  it('trims the query it quotes back', () => {
+    expect(emptySelectionNotice(schema, { search: '  zzz  ' })).toEqual({
+      message: 'No tables match "zzz".',
+      clearFocus: false,
+    });
+  });
+});


### PR DESCRIPTION
Closes #34.

Focusing a table and then filtering for one outside its neighbourhood emptied the diagram behind a banner that named neither, so the search looked broken. The composition itself is deliberate and stays: searching inside a focused neighbourhood is useful on a large schema. What was missing was the explanation and the escape.

## What changed

The empty-state banner now names what emptied the diagram, and offers a `Clear focus` action only when dropping the focus would actually show something:

| Situation | Message | Clear focus |
| --- | --- | --- |
| Filter misses inside a focus | `No tables match "roles" within focus: users.` | offered |
| Filter matches nothing at all | `No tables match "zzz".` | not offered |
| Focus alone matches nothing | `No tables match focus: gone.` | offered |
| Nothing scoped | the original generic message | not offered |

The third row is a case that was not in the report: a deep link to a table that config excludes on this connection used to give the same dead end.

Clearing keeps the filter that was typed, resets the Focus control, and drops `focus` from the URL.

## Structure

`selection.js` gains two pure functions:

- `selectTables()`, the filter-then-focus pipeline, which `truss.js` now delegates to instead of duplicating it in `currentSubset()`.
- `emptySelectionNotice()`, which decides the message and whether the escape applies.

That moves the decision out of the render path and makes it unit-testable. `banner()` takes an optional action button.

## Tests

Written first, both layers red before the fix:

- `tests/js/empty-state.test.js`: 11 Vitest cases over the pipeline and every notice branch, including the trimmed query and the empty-schema fallback.
- `tests/e2e/truss.spec.js`: two Playwright tests, the full interaction (focus, filter, banner, click, diagram returns, URL and controls updated) and the case where no button should appear.

Suites after the change: Vitest 94, Playwright 65, Pest 365, Pint clean.

## Not included

No README or docs change: neither documents the empty-state copy. The trussphp.com demo picks this up at the next release, since it fetches `resources/` from the latest tag, and the button is created in JS so the hand-authored demo shell needs no edit.

Reported by a user after the Laravel Daily video review, where the same confusion happens on screen at https://youtu.be/zogsFocamlU?t=123
