### PR TITLE
Drop em dashes from the dashboard copy

### DIFF
--- a/resources/js/truss.js
+++ b/resources/js/truss.js
@@ -954,7 +954,7 @@ function renderBanners(subsetCount) {
   const unscoped = !state.search && !state.focusRoot;
   if (unscoped && state.tables.length > config.warnAbove) {
     el.banners.append(banner('info',
-      `${state.tables.length} tables — large schema. Use the filter or focus a table to keep the diagram fast and legible.`));
+      `${state.tables.length} tables, a large schema. Use the filter or focus a table to keep the diagram fast and legible.`));
   }
   if (subsetCount === 0) {
     el.banners.append(banner('info', 'No tables match the current filter or focus.'));
@@ -1040,7 +1040,7 @@ function updateFooter() {
 /* ---- data ------------------------------------------------------------- */
 
 function populateFocusOptions() {
-  el.focus.innerHTML = ['<option value="">— none —</option>']
+  el.focus.innerHTML = ['<option value="">- none -</option>']
     .concat(state.tables.map((t) => `<option value="${t.name}">${t.name}</option>`))
     .join('');
   el.focus.value = state.focusRoot;

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -134,7 +134,7 @@
         <div class="truss-popover" id="truss-popover" hidden></div>
 
         <footer class="truss-footer">
-            <span id="truss-stat-tables">—</span>
+            <span id="truss-stat-tables">&nbsp;</span>
             <span id="truss-stat-conn"></span>
             <span class="truss-flag" id="truss-stat-fallback" hidden>SQLite&nbsp;fallback</span>
             <span class="truss-footer-spacer"></span>

--- a/tests/e2e/truss.spec.js
+++ b/tests/e2e/truss.spec.js
@@ -380,5 +380,5 @@ test('the connection switcher re-fetches and re-renders without reload', async (
 
 test('shows the large-schema warning above the configured threshold', async ({ page }) => {
   // primary has 4 tables, warn_above is 3, and nothing is filtered/focused.
-  await expect(banners(page)).toContainText('large schema');
+  await expect(banners(page)).toContainText('4 tables, a large schema.');
 });

--- a/tests/js/ui-copy.test.js
+++ b/tests/js/ui-copy.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The shipped dashboard is a user-facing prose surface like the README or the
+// docs site, so the house style applies to what it says on screen: no em or en
+// dashes. Code comments are left alone (they are not shown to anyone), which is
+// why the scan strips them first rather than reading whole files.
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+
+const SURFACES = ['resources/js', 'resources/css', 'resources/views'];
+const EXTS = new Set(['.js', '.css', '.php']);
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    // The vendored Mermaid bundle is third-party; its copy is not ours to edit.
+    if (entry.name === 'vendor') continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full));
+    } else if (EXTS.has(extname(entry.name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Drop comments so only what can reach the screen is scanned: /* ... *​/ blocks
+ * (JS and CSS) and whole-line // comments (JS). A trailing // comment on a line
+ * of code survives the strip, which is a deliberate simplification: it keeps the
+ * helper honest and readable, and the cost is a false positive that a reviewer
+ * can dismiss, never a miss on real copy.
+ */
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n');
+}
+
+const files = SURFACES.flatMap((dir) => walk(join(root, dir)));
+
+describe('shipped dashboard copy', () => {
+  it('finds the frontend source to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('uses no em or en dashes in anything the user can read', () => {
+    const offenders = [];
+    for (const file of files) {
+      stripComments(readFileSync(file, 'utf8')).split('\n').forEach((line, i) => {
+        if (line.includes('—') || line.includes('–')) {
+          offenders.push(`${file.replace(root, '')}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders, `em/en dash in shipped copy:\n${offenders.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
The house style rule that keeps em and en dashes out of the README, the docs and the site applies just as much to what the dashboard says on screen. Three strings had drifted.

## The copy

| Where | Before | After |
| --- | --- | --- |
| Large-schema banner | `42 tables` + an em dash + `large schema. Use the filter...` | `42 tables, a large schema. Use the filter...` |
| Focus picker, empty option | an em dash either side of `none` | `- none -` (plain hyphens, same look) |
| Footer table count, before load | a bare em dash | `&nbsp;` (blank, keeps the line height) |

## The guard

`tests/js/ui-copy.test.js` scans `resources/js`, `resources/css` and `resources/views` so these cannot drift back.

It strips comments before scanning, which is the point worth reviewing: the rule is about what a user reads, not about the source commentary, and there are a dozen dashes in comments across the frontend that are deliberately left alone. Whole-file scanning would have forced churn through unrelated files to make the test pass. The strip handles block comments and whole-line `//` comments; a trailing `//` comment on a line of code would still be scanned, which is a documented simplification that can only produce a false positive a reviewer dismisses, never a miss on real copy.

The vendored Mermaid bundle is skipped: third-party copy is not ours to edit.

## Tests

Written first, both red before the change: the Vitest guard listed exactly the three strings and ignored the comment ones, and the large-schema e2e assertion was tightened from `large schema` to the full new sentence.

Suites after: Vitest 85, Playwright 63, Pest 365, Pint clean.

## Notes

PHP sources carry em dashes too, but every one of them is in a docblock and none reach a user, so nothing there was touched. The trussphp.com demo shell has no dashes of its own, and the Focus picker copy comes from the shipped `truss.js`, so it follows at the next release with no docs-repo change.


