### PR TITLE
fix: introspect prefixed connections correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- On a connection configured with a table prefix (`'prefix' => 'portal_'`, or `DB_PREFIX`), every table rendered as an empty block: no columns, no types, no keys, and no relationship lines. Laravel reports table names exactly as the database stores them, prefix included, but prepends the prefix again to any name passed into its column, index and foreign key methods, so introspection was asking for `portal_portal_users` and getting an empty result back with no error to explain it. The prefix is now suspended for the duration of a snapshot, and introspection works in real database names throughout. Suspending it rather than trimming each name also covers a schema shared between apps, where the prefix separates the two and the other app's tables never carried it. The same fault silently dropped every native column comment from `truss:export` annotations on a prefixed connection, and is fixed with it. Reported by @locshino.
+
 ## [1.8.2] - 2026-08-12
 
 ### Fixed

--- a/src/Export/DatabaseCommentReader.php
+++ b/src/Export/DatabaseCommentReader.php
@@ -32,19 +32,26 @@ final class DatabaseCommentReader implements CommentReader
 
         $comments = [];
 
-        foreach ($builder->getTables() as $table) {
-            $name = $table['name'];
+        // Read in real database names, with the connection's table prefix
+        // suspended. getTables() reports names exactly as stored, prefix
+        // included, while getColumns() prepends the prefix again, so on a
+        // prefixed connection every column comment would silently go missing
+        // (issue #46). Mirrors SnapshotBuilder::introspect().
+        $builder->getConnection()->withoutTablePrefix(function () use ($builder, &$comments): void {
+            foreach ($builder->getTables() as $table) {
+                $name = $table['name'];
 
-            if ($this->present($table['comment'] ?? null)) {
-                $comments[$name] = (string) $table['comment'];
-            }
+                if ($this->present($table['comment'] ?? null)) {
+                    $comments[$name] = (string) $table['comment'];
+                }
 
-            foreach ($builder->getColumns($name) as $column) {
-                if ($this->present($column['comment'] ?? null)) {
-                    $comments["{$name}.{$column['name']}"] = (string) $column['comment'];
+                foreach ($builder->getColumns($name) as $column) {
+                    if ($this->present($column['comment'] ?? null)) {
+                        $comments["{$name}.{$column['name']}"] = (string) $column['comment'];
+                    }
                 }
             }
-        }
+        });
 
         return $comments;
     }

--- a/src/Introspection/SnapshotBuilder.php
+++ b/src/Introspection/SnapshotBuilder.php
@@ -161,20 +161,35 @@ class SnapshotBuilder
     {
         $builder = Schema::connection($connection);
 
-        return array_map(
-            fn (array $table): Table => new Table(
-                name: $table['name'],
-                columns: $this->columns($builder, $table['name']),
-                primaryKey: $this->primaryKey($builder, $table['name']),
-                indexes: $this->indexes($builder, $table['name']),
-                foreignKeys: $this->foreignKeys($builder, $table['name']),
+        // Introspect in real database names, with the connection's table prefix
+        // suspended for the pass. getTables() reports names exactly as the
+        // database stores them, prefix included, but the schema builder prepends
+        // the prefix again to anything handed to getColumns()/getIndexes()/
+        // getForeignKeys(). Passing the reported names straight back would look
+        // up "portal_portal_users", which exists nowhere, and every table would
+        // come back structurally empty with no error at all (issue #46).
+        //
+        // Suspending the prefix beats stripping it from each name: a prefix is
+        // often what separates two apps sharing one database, so the schema can
+        // hold tables the prefix never applied to, and those have nothing to
+        // strip. It also keeps foreign key targets in the same namespace as the
+        // table names, which is what the diagram matches edges on.
+        return $builder->getConnection()->withoutTablePrefix(
+            fn (): array => array_map(
+                fn (array $table): Table => new Table(
+                    name: $table['name'],
+                    columns: $this->columns($builder, $table['name']),
+                    primaryKey: $this->primaryKey($builder, $table['name']),
+                    indexes: $this->indexes($builder, $table['name']),
+                    foreignKeys: $this->foreignKeys($builder, $table['name']),
+                ),
+                // Scope to the connection's own schema. Since Laravel 12, a bare
+                // getTables() lists every schema on the server (issue #3), so on a
+                // shared host it would leak unrelated databases into the snapshot.
+                // getCurrentSchemaName() resolves per driver: the database name on
+                // MySQL, the search-path schema on PostgreSQL, 'main' on SQLite.
+                $builder->getTables($builder->getCurrentSchemaName()),
             ),
-            // Scope to the connection's own schema. Since Laravel 12, a bare
-            // getTables() lists every schema on the server (issue #3), so on a
-            // shared host it would leak unrelated databases into the snapshot.
-            // getCurrentSchemaName() resolves per driver: the database name on
-            // MySQL, the search-path schema on PostgreSQL, 'main' on SQLite.
-            $builder->getTables($builder->getCurrentSchemaName()),
         );
     }
 

--- a/tests/Feature/Export/DatabaseCommentReaderTest.php
+++ b/tests/Feature/Export/DatabaseCommentReaderTest.php
@@ -46,3 +46,26 @@ it('reads native table and column comments where the driver supports them', func
     expect($comments['commented'])->toBe('One row per thing.')
         ->and($comments['commented.status'])->toBe('0 draft, 1 paid');
 });
+
+it('reads column comments on a connection with a table prefix', function () {
+    // Issue #46, second site: the table comment comes off getTables() and is fine,
+    // but getColumns() prepends the prefix to a name that already carries it, so
+    // column comments silently vanish on any prefixed connection.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('Native comments need MySQL/Postgres; covered on those CI lanes.');
+    }
+
+    config(['database.connections.testing.prefix' => 'portal_']);
+    DB::purge('testing');
+
+    Schema::create('commented', function ($table) {
+        $table->id();
+        $table->string('status')->comment('0 draft, 1 paid');
+        $table->comment('One row per thing.');
+    });
+
+    $comments = (new DatabaseCommentReader)->read();
+
+    expect($comments['portal_commented'])->toBe('One row per thing.')
+        ->and($comments['portal_commented.status'])->toBe('0 draft, 1 paid');
+});

--- a/tests/Feature/Introspection/TablePrefixTest.php
+++ b/tests/Feature/Introspection/TablePrefixTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use AlbertoArena\Truss\Introspection\Data\Table;
+use AlbertoArena\Truss\Introspection\SnapshotBuilder;
+use Illuminate\Support\Facades\DB;
+
+/*
+ * Issue #46. When a connection configures a table prefix, getTables() reports the
+ * real, prefixed names, but Laravel's schema builder prepends the prefix again to
+ * anything passed into getColumns()/getIndexes()/getForeignKeys(). Feeding the
+ * reported names straight back in therefore looks up "portal_portal_users", which
+ * exists nowhere, and every table comes back structurally empty with no error.
+ *
+ * Introspection must report the real database names and their full structure
+ * whether or not a prefix is configured, and whether or not a given table
+ * actually carries it.
+ */
+
+const PREFIX = 'portal_';
+
+/**
+ * @return array<string, Table>
+ */
+function introspectPrefixed(): array
+{
+    return collect((new SnapshotBuilder)->introspect('testing'))->keyBy('name')->all();
+}
+
+beforeEach(function () {
+    // Rebuild the connection with a prefix, exactly as an app with
+    // DB_PREFIX=portal_ in config/database.php would boot it.
+    config(['database.connections.testing.prefix' => PREFIX]);
+    DB::purge('testing');
+
+    (require __DIR__.'/../../Fixtures/migrations/0001_01_01_000000_create_fixture_tables.php')->up();
+});
+
+it('reports the real prefixed table names', function () {
+    expect(array_keys(introspectPrefixed()))
+        ->toContain(PREFIX.'users', PREFIX.'posts', PREFIX.'post_tag');
+});
+
+it('introspects columns, types and defaults on a prefixed table', function () {
+    $posts = collect(introspectPrefixed()[PREFIX.'posts']->columns)->keyBy('name');
+
+    expect($posts)->not->toBeEmpty()
+        ->and($posts['title']->type)->toBeString()->not->toBeEmpty()
+        ->and($posts['title']->nullable)->toBeFalse()
+        ->and($posts['body']->nullable)->toBeTrue()
+        ->and($posts['status']->default)->not->toBeNull();
+});
+
+it('introspects the primary key on a prefixed table', function () {
+    expect(introspectPrefixed()[PREFIX.'users']->primaryKey)->toBe(['id'])
+        ->and(introspectPrefixed()[PREFIX.'post_tag']->primaryKey)->toBe(['post_id', 'tag_id']);
+});
+
+it('introspects indexes on a prefixed table', function () {
+    $emailIndex = collect(introspectPrefixed()[PREFIX.'users']->indexes)
+        ->firstWhere('columns', ['email']);
+
+    expect($emailIndex)->not->toBeNull()
+        ->and($emailIndex->unique)->toBeTrue();
+});
+
+it('introspects foreign keys whose targets match the reported table names', function () {
+    // The diagram draws an edge by matching referencesTable against a table name,
+    // so both sides have to carry the prefix or the relationship line is dropped.
+    $fk = collect(introspectPrefixed()[PREFIX.'posts']->foreignKeys)
+        ->firstWhere('referencesTable', PREFIX.'users');
+
+    expect($fk)->not->toBeNull()
+        ->and($fk->columns)->toBe(['user_id'])
+        ->and($fk->referencesColumns)->toBe(['id'])
+        ->and(strtolower((string) $fk->onDelete))->toBe('cascade');
+});
+
+it('introspects a table in the same schema that does not carry the prefix', function () {
+    // A prefix is often used to share one database between apps, so the schema can
+    // hold tables the prefix does not apply to. Stripping the prefix from the
+    // reported name is not enough on its own: these tables have nothing to strip
+    // and would still be looked up as "portal_legacy_audit".
+    DB::connection('testing')->statement('create table legacy_audit (id integer)');
+
+    $legacy = introspectPrefixed()['legacy_audit'] ?? null;
+
+    expect($legacy)->not->toBeNull()
+        ->and(collect($legacy->columns)->pluck('name')->all())->toBe(['id']);
+});
+
+it('leaves the connection prefix untouched after introspecting', function () {
+    (new SnapshotBuilder)->introspect('testing');
+
+    expect(DB::connection('testing')->getTablePrefix())->toBe(PREFIX);
+});
+
+it('still builds a serialized snapshot on a prefixed connection', function () {
+    $snapshot = (new SnapshotBuilder)->build('testing');
+
+    $users = collect($snapshot['tables'])->firstWhere('name', PREFIX.'users');
+
+    expect($snapshot['fallback'])->toBeFalse()
+        ->and($users['columns'])->not->toBeEmpty();
+});


### PR DESCRIPTION
Fixes #46.

## The bug

On a connection configured with a table prefix (`'prefix' => 'portal_'`, or `DB_PREFIX`), every table rendered as an empty block: no columns, no types, no keys, and no relationship lines.

`getTables()` reports names exactly as the database stores them, prefix included, but Laravel's schema builder prepends the prefix **again** to anything passed into `getColumns()` / `getIndexes()` / `getForeignKeys()`:

```php
// Illuminate\Database\Schema\Builder:393, 411, 486
$table = $this->connection->getTablePrefix().$table;
```

So introspection was asking for `portal_portal_users`, which exists nowhere, and getting empty arrays back with no error to explain it.

It went unnoticed because all three test connection lanes hardcoded `'prefix' => ''`.

## The fix

The prefix is suspended for the duration of a snapshot, via Laravel's own `Connection::withoutTablePrefix()` (present since v12.0.0, so the `^12.0` floor is safe), and introspection works in real database names throughout.

Suspending the prefix rather than trimming it off each reported name is deliberate, and there is a test pinning why. A prefix is often what separates two apps sharing one database, so the schema can hold tables the prefix never applied to. Those have nothing to trim, and a trim-based fix would still look them up with the prefix bolted on. Working in real names also keeps foreign key targets in the same namespace as the table names, which is what the diagram matches its edges on: a mismatch there silently drops every relationship line.

Reported table names stay prefixed, since that is what the database actually contains.

## Second site

The same fault silently dropped every native column comment from the `truss:export` annotations on a prefixed connection. `DatabaseCommentReader` gets the same treatment.

## Tests

TDD, red first on both sites.

* `tests/Feature/Introspection/TablePrefixTest.php`, new, 8 cases against a real prefixed connection: columns and defaults, primary key (single and composite), indexes, foreign keys whose targets match the reported names, a table in the same schema that does **not** carry the prefix, the prefix being left untouched afterwards, and the serialized snapshot. 6 of the 8 failed before the fix, and the 2 that passed were the ones that should have.
* `DatabaseCommentReaderTest`, one added case. It needs MySQL or Postgres, since the reader no-ops on SQLite, so it was driven red on a real MySQL lane: the table comment resolved, the column comment was undefined.

Full suite green on both lanes, 388 passed on SQLite and 389 on MySQL, Pint clean.

## Not in scope

`DatabaseCommentReader` still calls a bare `getTables()` with no schema argument, which is the same cross-database leak `SnapshotBuilder` guards against with `getCurrentSchemaName()` (#3). Different bug, different blast radius, filed separately.
