### PR TITLE
chore: release v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-08-12
+
 ### Fixed
 
 - On a connection configured with a table prefix (`'prefix' => 'portal_'`, or `DB_PREFIX`), every table rendered as an empty block: no columns, no types, no keys, and no relationship lines. Laravel reports table names exactly as the database stores them, prefix included, but prepends the prefix again to any name passed into its column, index and foreign key methods, so introspection was asking for `portal_portal_users` and getting an empty result back with no error to explain it. The prefix is now suspended for the duration of a snapshot, and introspection works in real database names throughout. Suspending it rather than trimming each name also covers a schema shared between apps, where the prefix separates the two and the other app's tables never carried it. The same fault silently dropped every native column comment from `truss:export` annotations on a prefixed connection, and is fixed with it. Reported by @locshino.


### PR DESCRIPTION
Changelog bump for **v1.8.3**, a patch release carrying the two fixes already merged in #47 and #48. No code changes here.

Planned release title:

> v1.8.3: prefixed connections no longer render empty tables

## What ships

- **#47**, table prefixes. On a connection with `'prefix' => 'portal_'` or `DB_PREFIX`, every table rendered as an empty block: no columns, no types, no keys, no relationship lines. Reported by @locshino.
- **#48**, export comment scoping. Annotations could pick up table and column comments from an unrelated database on the same server, so a same-named table elsewhere could annotate yours with another application's meaning.

Both are pure fixes. No config knob, command, or route surface moved, which is what makes this a patch rather than a minor.

## Gates

All green on `2feaacf` before this bump:

- 12 of 12 CI checks, including the Postgres lane, which was the one branch of #48's test I could not exercise locally.
- Local: `composer test` (388 passed), `composer lint`, `npm test` (96 passed), `npx playwright test` (72 passed).

## After merge

1. Annotated tag `v1.8.3` on the merge commit, pushed.
2. GitHub release from the changelog entry, carrying the `Reported by @locshino.` credit on the release notes as well as in the changelog.
3. Verify Packagist picks up the tag.
4. Trigger a docs site rebuild, since trussphp.com reads from the latest release and does not redeploy on its own.
5. Reply to @locshino on #46 once it is actually live.
