### PR TITLE
Add TRUSS-INT-004: foreign key points at the wrong table

### DIFF
--- a/src/Doctor/RuleRegistry.php
+++ b/src/Doctor/RuleRegistry.php
@@ -11,6 +11,7 @@ use AlbertoArena\Truss\Doctor\Rules\Index\IndexDuplicatingPrimaryKey;
 use AlbertoArena\Truss\Doctor\Rules\Index\MissingUniqueConstraint;
 use AlbertoArena\Truss\Doctor\Rules\Index\RedundantPrefixIndex;
 use AlbertoArena\Truss\Doctor\Rules\Index\UnindexedSoftDelete;
+use AlbertoArena\Truss\Doctor\Rules\Integrity\ForeignKeyPointsAtWrongTable;
 use AlbertoArena\Truss\Doctor\Rules\Integrity\ForeignKeyTypeMismatch;
 use AlbertoArena\Truss\Doctor\Rules\Integrity\LikelyMissingForeignKey;
 use AlbertoArena\Truss\Doctor\Rules\Integrity\MissingPrimaryKey;
@@ -44,6 +45,7 @@ final class RuleRegistry
             new MissingPrimaryKey,
             new LikelyMissingForeignKey,
             new ForeignKeyTypeMismatch,
+            new ForeignKeyPointsAtWrongTable,
             new PivotWithoutUniqueKey,
             new PolymorphicWithoutIndex,
             new ForeignKeyWithoutIndex,

--- a/src/Doctor/Rules/Integrity/ForeignKeyPointsAtWrongTable.php
+++ b/src/Doctor/Rules/Integrity/ForeignKeyPointsAtWrongTable.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlbertoArena\Truss\Doctor\Rules\Integrity;
+
+use AlbertoArena\Truss\Doctor\Category;
+use AlbertoArena\Truss\Doctor\Confidence;
+use AlbertoArena\Truss\Doctor\Contracts\Rule;
+use AlbertoArena\Truss\Doctor\Finding;
+use AlbertoArena\Truss\Doctor\Severity;
+use Illuminate\Support\Str;
+
+/**
+ * TRUSS-INT-004: a single-column `*_id` foreign key that references one table
+ * while a table named after the column exists and is a different one. The
+ * constraint then validates against the wrong parent, so a valid id is rejected
+ * unless it happens to exist in both tables, and `ON DELETE CASCADE` deletes
+ * rows when the wrong parent goes.
+ *
+ * This is the sibling of TRUSS-INT-002. That rule asks why a foreign-key-shaped
+ * column has no constraint; this one asks why the constraint it has disagrees
+ * with its name.
+ *
+ * THE WHOLE DIFFICULTY IS THAT MOST NAME MISMATCHES ARE DELIBERATE. Aliases are
+ * ordinary and correct: `author_id` referencing `users`, `merged_id` referencing
+ * `carts`, `parent_transaction_id` referencing `transactions`. Measured on
+ * Lunar 1.5.0, six of the seven mismatches among 83 foreign keys were aliases of
+ * that kind, so a rule that flagged every mismatch would have been wrong 86% of
+ * the time.
+ *
+ * So the test is not "the names differ". It is "the name names a table that
+ * actually exists, and the key points somewhere else". An alias survives because
+ * there is no `authors` or `mergeds` table for its name to name. The rule stays
+ * quiet unless exactly one candidate resolves, and a prefixed schema is matched
+ * through the prefix of the table the key already references, so `lunar_` tables
+ * are neither invisible nor confused with another application's.
+ */
+final class ForeignKeyPointsAtWrongTable implements Rule
+{
+    public function code(): string
+    {
+        return 'TRUSS-INT-004';
+    }
+
+    public function category(): Category
+    {
+        return Category::Integrity;
+    }
+
+    public function confidence(): Confidence
+    {
+        return Confidence::High;
+    }
+
+    public function defaultSeverity(): Severity
+    {
+        return Severity::Error;
+    }
+
+    public function title(): string
+    {
+        return 'Foreign key references a different table from the one it is named after';
+    }
+
+    public function check(array $snapshot, string $connection): iterable
+    {
+        $tables = $snapshot['tables'] ?? [];
+        $tableNames = array_column($tables, 'name');
+
+        foreach ($tables as $table) {
+            $columnNames = array_column($table['columns'] ?? [], 'name');
+
+            foreach ($table['foreign_keys'] ?? [] as $foreignKey) {
+                $columns = $foreignKey['columns'] ?? [];
+
+                // A composite key is not named after one table, so there is no
+                // name to test.
+                if (count($columns) !== 1) {
+                    continue;
+                }
+
+                $column = $columns[0];
+
+                if (! str_ends_with($column, '_id')) {
+                    continue;
+                }
+
+                $base = substr($column, 0, -3);
+
+                if ($base === '') {
+                    continue;
+                }
+
+                // A morph target points at whichever table its sibling `_type`
+                // column names, so its own name is not a claim about one table.
+                // TRUSS-INT-009 owns that shape.
+                if (in_array($base.'_type', $columnNames, true)) {
+                    continue;
+                }
+
+                $referenced = $foreignKey['references_table'] ?? null;
+
+                if (! is_string($referenced) || $referenced === '') {
+                    continue;
+                }
+
+                $named = $this->tableTheNameNames($base, $tableNames, $referenced);
+
+                if ($named === null || $named === $referenced) {
+                    continue;
+                }
+
+                yield new Finding(
+                    code: $this->code(),
+                    severity: $this->defaultSeverity(),
+                    connection: $connection,
+                    table: $table['name'],
+                    column: $column,
+                    message: "Foreign key \"{$table['name']}.{$column}\" references \"{$referenced}\", but a table named \"{$named}\" exists and is what the column name points to.",
+                    hint: 'A foreign key validates against the table it references, so this one rejects a valid id unless the same id also exists in the referenced table, and ON DELETE CASCADE fires when the wrong parent row is deleted. If the reference is a deliberate alias, add it to the doctor ignore list.',
+                    suggestion: null,
+                );
+            }
+        }
+    }
+
+    /**
+     * The table a `*_id` base names, or null when the name names nothing, or
+     * names more than one thing.
+     *
+     * Candidates are tried plural first, then singular, and the first candidate
+     * that resolves wins. A candidate resolves only when exactly one table
+     * matches it: either the table is called exactly that, or it is called that
+     * under a prefix which the referenced table also carries. More than one
+     * match is ambiguous, and guessing is worse than silence.
+     *
+     * @param  list<string>  $tableNames
+     */
+    private function tableTheNameNames(string $base, array $tableNames, string $referenced): ?string
+    {
+        $candidates = array_unique([Str::plural($base), $base]);
+
+        foreach ($candidates as $candidate) {
+            $matches = [];
+
+            foreach ($tableNames as $name) {
+                if ($name === $candidate) {
+                    $matches[] = $name;
+
+                    continue;
+                }
+
+                if (! str_ends_with($name, '_'.$candidate)) {
+                    continue;
+                }
+
+                $prefix = substr($name, 0, -strlen($candidate));
+
+                // Same prefix as the table the key already points at, so this
+                // is the same application's schema rather than another one
+                // that happens to use the word.
+                if (str_starts_with($referenced, $prefix)) {
+                    $matches[] = $name;
+                }
+            }
+
+            if (count($matches) === 1) {
+                return $matches[0];
+            }
+
+            if ($matches !== []) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Support/TableDraft.php
+++ b/tests/Support/TableDraft.php
@@ -24,6 +24,9 @@ final class TableDraft
     /** @var list<array{column: string, table: string, column_ref: string}> */
     private array $fkDrafts = [];
 
+    /** @var list<array{columns: list<string>, table: string, columns_ref: list<string>}> */
+    private array $compositeFkDrafts = [];
+
     private ?string $pendingFk = null;
 
     /** An auto-incrementing bigint primary key. */
@@ -75,6 +78,25 @@ final class TableDraft
     public function foreign(string $column, string $table, string $referencedColumn = 'id'): self
     {
         $this->fkDrafts[] = ['column' => $column, 'table' => $table, 'column_ref' => $referencedColumn];
+
+        return $this;
+    }
+
+    /**
+     * Add a multi-column foreign key. Separate from foreign() because a rule
+     * that reads a key's name has to be able to prove it skips one that does
+     * not have a single column to read.
+     *
+     * @param  list<string>  $columns
+     * @param  list<string>|null  $referencedColumns  defaults to `id` per column
+     */
+    public function compositeForeign(array $columns, string $table, ?array $referencedColumns = null): self
+    {
+        $this->compositeFkDrafts[] = [
+            'columns' => $columns,
+            'table' => $table,
+            'columns_ref' => $referencedColumns ?? array_fill(0, count($columns), 'id'),
+        ];
 
         return $this;
     }
@@ -137,17 +159,30 @@ final class TableDraft
             'columns' => $this->columns,
             'primary_key' => $this->primaryKey,
             'indexes' => $this->indexes,
-            'foreign_keys' => array_map(
-                fn (array $fk): array => [
-                    'name' => "{$name}_{$fk['column']}_foreign",
-                    'columns' => [$fk['column']],
-                    'references_table' => $fk['table'],
-                    'references_columns' => [$fk['column_ref']],
-                    'on_update' => null,
-                    'on_delete' => null,
-                ],
-                $this->fkDrafts,
-            ),
+            'foreign_keys' => [
+                ...array_map(
+                    fn (array $fk): array => [
+                        'name' => "{$name}_{$fk['column']}_foreign",
+                        'columns' => [$fk['column']],
+                        'references_table' => $fk['table'],
+                        'references_columns' => [$fk['column_ref']],
+                        'on_update' => null,
+                        'on_delete' => null,
+                    ],
+                    $this->fkDrafts,
+                ),
+                ...array_map(
+                    fn (array $fk): array => [
+                        'name' => "{$name}_".implode('_', $fk['columns']).'_foreign',
+                        'columns' => $fk['columns'],
+                        'references_table' => $fk['table'],
+                        'references_columns' => $fk['columns_ref'],
+                        'on_update' => null,
+                        'on_delete' => null,
+                    ],
+                    $this->compositeFkDrafts,
+                ),
+            ],
         ];
     }
 }

--- a/tests/Unit/Doctor/RuleRegistryTest.php
+++ b/tests/Unit/Doctor/RuleRegistryTest.php
@@ -12,7 +12,7 @@ function ruleCodes(array $rules): array
 }
 
 it('registers the phase 1 rules by default', function () {
-    expect(RuleRegistry::default()->all())->toHaveCount(13);
+    expect(RuleRegistry::default()->all())->toHaveCount(14);
 });
 
 it('recommended runs high-confidence rules only', function () {
@@ -26,7 +26,7 @@ it('recommended runs high-confidence rules only', function () {
 });
 
 it('strict runs every rule and none runs nothing', function () {
-    expect(RuleRegistry::default()->resolve('strict'))->toHaveCount(13);
+    expect(RuleRegistry::default()->resolve('strict'))->toHaveCount(14);
     expect(RuleRegistry::default()->resolve('none'))->toBe([]);
 });
 

--- a/tests/Unit/Doctor/Rules/ForeignKeyPointsAtWrongTableTest.php
+++ b/tests/Unit/Doctor/Rules/ForeignKeyPointsAtWrongTableTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use AlbertoArena\Truss\Doctor\Rules\Integrity\ForeignKeyPointsAtWrongTable;
+use AlbertoArena\Truss\Tests\Support\SchemaBuilder;
+
+it('flags a foreign key that points at a different table from the one its name names', function () {
+    // The case this rule was written for, found in Lunar 1.5.0 on 01/09/2026:
+    // cart_line_discount.cart_line_id is constrained against carts, not
+    // cart_lines, so the cascade fires on the wrong parent and an insert only
+    // succeeds when the cart line id happens to also exist as a cart id.
+    $snapshot = SchemaBuilder::make()
+        ->table('carts', fn ($t) => $t->id())
+        ->table('cart_lines', fn ($t) => $t->id())
+        ->table('cart_line_discount', fn ($t) => $t->id()->foreignId('cart_line_id')->on('carts'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))
+        ->toHaveFinding('TRUSS-INT-004', table: 'cart_line_discount', column: 'cart_line_id');
+});
+
+it('is clean when the foreign key points at the table its name names', function () {
+    $snapshot = SchemaBuilder::make()
+        ->table('carts', fn ($t) => $t->id())
+        ->table('cart_lines', fn ($t) => $t->id())
+        ->table('cart_line_discount', fn ($t) => $t->id()->foreignId('cart_line_id')->on('cart_lines'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('matches a singular table name as well as a plural one', function () {
+    $snapshot = SchemaBuilder::make()
+        ->table('cart', fn ($t) => $t->id())
+        ->table('cart_line', fn ($t) => $t->id())
+        ->table('cart_line_discount', fn ($t) => $t->id()->foreignId('cart_line_id')->on('cart'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))
+        ->toHaveFinding('TRUSS-INT-004', table: 'cart_line_discount', column: 'cart_line_id');
+});
+
+// The false positives this rule exists to avoid. Six of the seven column/table
+// name mismatches in Lunar's 83 foreign keys are deliberate aliases, so a rule
+// that flags every mismatch would be 86% wrong. All six shapes are below and
+// none of them may fire.
+
+it('does not flag an alias whose named table does not exist', function () {
+    // merged_id -> carts, parent_transaction_id -> transactions,
+    // product_parent_id -> products. There is no mergeds, parent_transactions
+    // or product_parents table, so the name names nothing and there is no
+    // disagreement to report.
+    $snapshot = SchemaBuilder::make()
+        ->table('carts', fn ($t) => $t->id()->foreignId('merged_id')->on('carts'))
+        ->table('transactions', fn ($t) => $t->id()->foreignId('parent_transaction_id')->on('transactions'))
+        ->table('products', fn ($t) => $t->id())
+        ->table('product_associations', fn ($t) => $t->id()
+            ->foreignId('product_parent_id')->on('products')
+            ->foreignId('product_target_id')->on('products'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('does not flag a shortened column name that already points at the right table', function () {
+    // value_id -> product_option_values and variant_id -> product_variants.
+    // The referenced table ends with the plural of the column base, so the
+    // shortened name is an abbreviation of the target rather than a different
+    // table.
+    $snapshot = SchemaBuilder::make()
+        ->table('product_option_values', fn ($t) => $t->id())
+        ->table('product_variants', fn ($t) => $t->id())
+        ->table('product_option_value_product_variant', fn ($t) => $t->id()
+            ->foreignId('value_id')->on('product_option_values')
+            ->foreignId('variant_id')->on('product_variants'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('finds the table through a shared prefix', function () {
+    // Lunar prefixes every table with lunar_. The candidate is found by taking
+    // the prefix off the table the key already references, so a prefixed schema
+    // is not invisible to this rule.
+    $snapshot = SchemaBuilder::make()
+        ->table('lunar_carts', fn ($t) => $t->id())
+        ->table('lunar_cart_lines', fn ($t) => $t->id())
+        ->table('lunar_cart_line_discount', fn ($t) => $t->id()->foreignId('cart_line_id')->on('lunar_carts'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))
+        ->toHaveFinding('TRUSS-INT-004', table: 'lunar_cart_line_discount', column: 'cart_line_id');
+});
+
+it('does not match across different prefixes', function () {
+    // A cart_lines table exists, but under a different prefix from the one the
+    // key references, so it is a different application's table and not evidence
+    // that this key is wrong.
+    $snapshot = SchemaBuilder::make()
+        ->table('lunar_carts', fn ($t) => $t->id())
+        ->table('shop_cart_lines', fn ($t) => $t->id())
+        ->table('lunar_cart_line_discount', fn ($t) => $t->id()->foreignId('cart_line_id')->on('lunar_carts'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('skips when more than one table could be the intended target', function () {
+    // "lines" exists unprefixed, and "shop_lines" exists under the same prefix
+    // as the referenced table. Both are plausible and choosing either one would
+    // be a guess, so the rule says nothing.
+    $snapshot = SchemaBuilder::make()
+        ->table('lines', fn ($t) => $t->id())
+        ->table('shop_lines', fn ($t) => $t->id())
+        ->table('shop_carts', fn ($t) => $t->id())
+        ->table('shop_line_discount', fn ($t) => $t->id()->foreignId('line_id')->on('shop_carts'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('skips a morph target, which cannot name one table', function () {
+    // A *_id with a sibling *_type points at whichever table the type column
+    // names, so its name is not a claim about a single table. TRUSS-INT-009
+    // owns this shape.
+    $snapshot = SchemaBuilder::make()
+        ->table('users', fn ($t) => $t->id())
+        ->table('owners', fn ($t) => $t->id())
+        ->table('things', fn ($t) => $t->id()->string('owner_type')->foreignId('owner_id')->on('users'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('skips a composite foreign key', function () {
+    // A multi-column key is not named after one table, so the name test does
+    // not apply.
+    $snapshot = SchemaBuilder::make()
+        ->table('carts', fn ($t) => $t->id())
+        ->table('cart_lines', fn ($t) => $t->id())
+        ->table('cart_line_discount', fn ($t) => $t->id()
+            ->integer('cart_line_id')
+            ->integer('tenant_id')
+            ->compositeForeign(['cart_line_id', 'tenant_id'], 'carts'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('ignores a column that is not foreign-key shaped', function () {
+    $snapshot = SchemaBuilder::make()
+        ->table('carts', fn ($t) => $t->id())
+        ->table('cart_lines', fn ($t) => $t->id())
+        ->table('cart_line_discount', fn ($t) => $t->id()->integer('quantity')->foreign('quantity', 'carts'))
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('is clean on a schema with no foreign keys at all', function () {
+    $snapshot = SchemaBuilder::make()
+        ->table('carts', fn ($t) => $t->id())
+        ->table('cart_lines', fn ($t) => $t->id())
+        ->build();
+
+    expect(doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot))->toBeClean();
+});
+
+it('names both tables in the message, because the fix is unreadable without them', function () {
+    $snapshot = SchemaBuilder::make()
+        ->table('carts', fn ($t) => $t->id())
+        ->table('cart_lines', fn ($t) => $t->id())
+        ->table('cart_line_discount', fn ($t) => $t->id()->foreignId('cart_line_id')->on('carts'))
+        ->build();
+
+    $findings = doctorCheck(new ForeignKeyPointsAtWrongTable, $snapshot);
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->message)->toContain('carts')
+        ->and($findings[0]->message)->toContain('cart_lines');
+});


### PR DESCRIPTION
## What this finds

A single-column `*_id` foreign key that references one table while a table named after the column exists and is a different one.

Found on **Lunar 1.5.0**:

```php
// 2022_11_18_100005_create_cart_line_discount_table.php
$table->foreignId('cart_line_id')->constrained($this->prefix.'carts')->cascadeOnDelete();
```

`lunar_cart_line_discount.cart_line_id` is constrained against `lunar_carts`, not `lunar_cart_lines`. `CartLine::discounts()` is a `belongsToMany` through that table, so the application writes cart line ids into a column validated against cart ids. Three consequences:

1. An insert only succeeds when the cart line id happens to also exist as a cart id.
2. `ON DELETE CASCADE` fires on the wrong parent: deleting a **cart** deletes discount rows whose `cart_line_id` merely equals that cart's id.
3. Deleting a cart line cascades nothing, leaving orphans.

No existing rule could see it.

## Why this was not obvious to get right

**Most name mismatches are deliberate and correct.** Measured on Lunar: **6 of the 7** mismatches among its 83 foreign keys are aliases (`merged_id`, `parent_transaction_id`, `product_parent_id`, `product_target_id`, `value_id`, `variant_id`). A rule that flagged every mismatch would be **wrong 86% of the time**, which is the same calibration trap as the 69-to-14 episode in the field study.

So the test is not "the names differ". It is **"the name names a table that actually exists, and the key points somewhere else"**. An alias survives because there is no `authors` or `mergeds` table for its name to name.

Two further guards:

- **Ambiguity is silence.** Candidates resolve plural first then singular, and only when exactly one table matches. More than one and the rule says nothing rather than guessing.
- **Prefixes are handled through the referenced table.** `lunar_` tables are found via the prefix the key already carries, so a prefixed schema is neither invisible nor confused with another application's tables.

Morph targets and composite keys are skipped: neither is named after one table.

## Tests

TDD, 13 cases. All six alias shapes are must-not-fire tests alongside the positive, plus prefix matching, cross-prefix rejection, ambiguity, morphs, composite keys and the message contents.

**Verified end to end against the real Lunar database**: exactly one finding, on the right column, and none of the six aliases.

Full suite green (453 passed), Pint clean.

## Release note

This is doctor-rule work, so it belongs in **v1.12 under order A** (v1.11 HTML export, v1.12 doctor rules, v1.13 PHAR), not in v1.11. Opening now so the rule is reviewable while the finding is fresh.

`TRUSS-INT-004` takes the first free code. The rules brief uses `TRUSS-INT-0xx` placeholders and says to renumber to fit, so this does not collide with anything planned.