### PR TITLE
Cap the popover clear of its own content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The details popover no longer clips its own content. Its height cap sat inside
+  the range two browsers disagree by when measuring the same menu, so the note
+  explaining why the server-backed exports are unavailable could scroll out of
+  sight in one and not the other. The cap now clears the tallest content the
+  popover carries, and can no longer exceed the window it is placed in.
+
 ## [1.11.0] - 2026-09-01
 
 ### Added

--- a/resources/css/truss.css
+++ b/resources/css/truss.css
@@ -405,8 +405,40 @@ body {
 #truss-canvas svg .nodeLabel.truss-enum-type:hover,
 #truss-canvas svg .nodeLabel.truss-enum-type:hover p { color: var(--bp-ink) !important; }
 
+/* One cap, and it governs one shared element with four different contents: the
+   enum value list (truss.js:331), the table menu (:376), the Export view menu
+   (:640) and the column detail (:980). Raising it therefore reaches real
+   installations and not only the server-less demo, which is a decision rather
+   than a side effect. It is a safe one because the change is monotone: every
+   content shows more before it scrolls and none shows less. The only content
+   with no natural bound is the enum list, one row per value, which scrolled at
+   280 and simply scrolls later now. Scoping per content would need :has(),
+   which costs more browser floor than the whole fix.
+
+   The size clears the tallest thing the popover ships: a menu carrying the "no
+   export route" note, which measures 264px under Playwright's Chromium and 294
+   under Chrome against this same stylesheet, a 30px spread from text metrics.
+   A flat 280 sat inside that spread, so the note explaining why four items were
+   dimmed scrolled off the bottom in some browsers and not others. Both the
+   table menu and the Export view menu carry that note (truss.js:384 and :648),
+   so the defect had two entry points.
+
+   The viewport term is not belt and braces. placePopover flips the menu above
+   its anchor when it will not fit below and pins it to 8px, so it cannot shrink
+   what it is given, and a taller flat cap would trade a clipped menu for one
+   running off the bottom of a short window. dvh is declared second because on
+   iOS Safari 100vh is the toolbars-retracted height, which would reintroduce
+   exactly that failure on the device a demo link is most often opened on; a
+   browser that does not know dvh keeps the vh line above it.
+
+   min() needs no fallback. A browser that cannot parse it drops the whole
+   declaration, which leaves no cap at all: nothing clips, and the only cost is
+   the short-window overrun that this change removes. The degradation is
+   benign, which is why the older syntax is not worth carrying. */
 .truss-popover {
-  position: fixed; z-index: 40; min-width: 120px; max-width: 260px; max-height: 280px; overflow: auto;
+  position: fixed; z-index: 40; min-width: 120px; max-width: 260px;
+  max-height: min(360px, calc(100vh - 16px));
+  max-height: min(360px, calc(100dvh - 16px)); overflow: auto;
   background: var(--bp-panel); border: 1px solid var(--bp-panel-line); border-radius: 4px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, .2); padding: 10px 12px;
   font-family: var(--bp-mono); font-size: 12px; color: var(--bp-fg);

--- a/tests/e2e/export-availability.spec.js
+++ b/tests/e2e/export-availability.spec.js
@@ -25,7 +25,7 @@ const base = {
  * @param {import('@playwright/test').Page} page
  * @param {{ server?: boolean }} options
  */
-async function load(page, { server = true } = {}) {
+async function load(page, { server = true, css = false } = {}) {
   await page.route('**/api/schema**', (route) =>
     route.fulfill({ contentType: 'application/json', body: JSON.stringify(base) }));
 
@@ -33,14 +33,20 @@ async function load(page, { server = true } = {}) {
     // Served without the attribute at all, which is what a static page does.
     // It cannot be stripped from a script: truss.js reads its config once, at
     // module evaluation, and a deferred module runs before DOMContentLoaded.
-    await page.route('**/harness.html', async (route) => {
+    // The glob keeps the trailing * so it still matches with ?css=1 appended.
+    await page.route('**/harness.html*', async (route) => {
       const response = await route.fetch();
       const html = (await response.text()).replace(/\s*data-export-endpoint="[^"]*"/, '');
       await route.fulfill({ response, body: html, contentType: 'text/html' });
     });
   }
 
-  await page.goto('/tests/e2e/harness.html');
+  // ?css=1 loads the real stylesheet. Off by default here, as everywhere else,
+  // because the webfont moves text metrics and these specs assert on the DOM.
+  // The two size assertions below are about the stylesheet itself, so they are
+  // the ones that need it: without it the popover has no max-height at all and
+  // measures 898px wide, which cannot show a cap being too small.
+  await page.goto(`/tests/e2e/harness.html${css ? '?css=1' : ''}`);
   await expect(page.locator('#truss-canvas > svg')).toBeVisible();
 }
 
@@ -119,4 +125,98 @@ test('the table menu marks its server-backed actions too', async ({ page }) => {
   // Focus needs nothing from a server and must survive.
   await expect(page.locator('#truss-popover button[data-act="focus"]'))
     .not.toHaveAttribute('aria-disabled', 'true');
+});
+
+// The note explaining why four items are unavailable is 92px of text, and the
+// popover was capped at a flat 280px. On trussphp.com's demo the menu measures
+// 294 with the note in it, so the explanation was the part that fell off the
+// bottom: the reader saw four dimmed items and had to scroll a menu to find out
+// why, on a page whose whole job is to be tried by somebody who has installed
+// nothing.
+//
+// This asserts headroom rather than "does not scroll", and the difference
+// matters. The same menu measures 264 under Playwright's Chromium and 294 in
+// the Chrome it was reported from, against a byte-identical stylesheet: a 30px
+// spread. Font substitution is not the cause, since serve.mjs points every
+// woff2 request at resources/fonts and both are measuring the real face; the
+// cause is unidentified and the fix does not depend on knowing it. What matters
+// is the size of the spread, because a spec that only checked for a scrollbar
+// would pass in this harness while the shipped page clipped. The cap has to
+// clear its own content by more than the spread, or whether it clips is decided
+// by which browser is looking.
+//
+// Only reachable without an export route, which is why it lives in this file:
+// with one there is no note and the menu measures 194.
+const METRIC_SPREAD = 48;
+
+test('caps the table menu well clear of its own content', async ({ page }) => {
+  // Explicit, because the assertion reads the computed max-height and that
+  // resolves the min(). Anywhere shorter than about 376px it would resolve to
+  // the viewport term instead, and the test would start failing for a reason
+  // that has nothing to do with the cap this is about.
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await load(page, { server: false, css: true });
+
+  await page.locator('#truss-canvas [role="button"]').first().click();
+  await expect(page.locator('#truss-popover')).toBeVisible();
+  await expect(page.locator('#truss-popover .truss-menu-note')).toBeVisible();
+
+  const box = await page.locator('#truss-popover').evaluate((el) => ({
+    content: el.scrollHeight,
+    cap: parseFloat(getComputedStyle(el).maxHeight),
+  }));
+
+  expect(box.cap - box.content,
+    `the cap is ${box.cap}px against ${box.content}px of content, and the same menu `
+    + 'has been measured 30px taller in another browser')
+    .toBeGreaterThanOrEqual(METRIC_SPREAD);
+});
+
+// Guards the fix rather than driving it: raising a flat cap is how you trade a
+// clipped menu for one that runs off the bottom of a short window, since
+// placePopover pins to 8px from the top when it flips above and cannot shrink
+// what it is given. 240px is below the menu's own 294, so an unclamped cap
+// fails here while the clamped one shrinks and scrolls inside itself.
+test('caps the Export view menu clear of its content too', async ({ page }) => {
+  // The same note fills this menu on the same `server` condition
+  // (truss.js:648), so the reported defect had two entry points and only one of
+  // them was covered. One element and one cap fixes both, which is an argument
+  // for the shared cap, but it should be asserted rather than assumed.
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await load(page, { server: false, css: true });
+
+  // dispatchEvent rather than click, and only here. This harness puts
+  // .truss-zoom inside the toolbar, where the shipped views put it inside
+  // #truss-viewport, so once the real stylesheet applies position: absolute it
+  // lands on top of the export button and swallows the pointer. That is a
+  // divergence in the harness markup and not something a user meets, so the
+  // handler is invoked directly rather than asserting around a fake obstacle.
+  await page.locator('#truss-export-btn').dispatchEvent('click');
+
+  await expect(page.locator('#truss-popover .truss-menu-note')).toBeVisible();
+
+  const box = await page.locator('#truss-popover').evaluate((el) => ({
+    content: el.scrollHeight,
+    cap: parseFloat(getComputedStyle(el).maxHeight),
+  }));
+
+  expect(box.cap - box.content, `the cap is ${box.cap}px against ${box.content}px of content`)
+    .toBeGreaterThanOrEqual(METRIC_SPREAD);
+});
+
+test('never grows taller than the window it is placed in', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 240 });
+  await load(page, { server: false, css: true });
+
+  await page.locator('#truss-canvas [role="button"]').first().click();
+  await expect(page.locator('#truss-popover')).toBeVisible();
+
+  const fits = await page.locator('#truss-popover').evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return { top: Math.round(r.top), bottom: Math.round(r.bottom), windowH: window.innerHeight };
+  });
+
+  expect(fits.top, 'the menu starts above the top of the window').toBeGreaterThanOrEqual(0);
+  expect(fits.bottom, `the menu ends ${fits.bottom - fits.windowH}px below the bottom of the window`)
+    .toBeLessThanOrEqual(fits.windowH);
 });

--- a/tests/e2e/harness.html
+++ b/tests/e2e/harness.html
@@ -36,7 +36,21 @@
         .truss-combo-opt { padding: 3px 8px; cursor: pointer; }
         .truss-combo-opt.is-active { background: #dbeafe; }
         .truss-sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
-        .truss-popover { position: fixed; z-index: 40; background: #fff; border: 1px solid #ccc; padding: 8px; }
+        /* :where() so this stands in only when the real stylesheet is absent.
+           It is a stub for the specs that run without ?css=1, but it was
+           winning the cascade even with it, because it is declared after the
+           injected link and matches at the same specificity. That made the
+           popover's real box invisible to every spec: a shipped max-height too
+           small for its own content measured correct in here.
+
+           Zero specificity rather than reordering the head, and the reason is
+           correctness rather than a smaller diff. :where(.truss-popover) is
+           0,0,0 against truss.css's 0,1,0, so it loses whatever the source
+           order is. Moving the injected link would work only while that order
+           held, and the next person to add a <style> or reorder the head would
+           silently re-mask the popover, which is the bug this exists to have
+           caught. */
+        :where(.truss-popover) { position: fixed; z-index: 40; background: #fff; border: 1px solid #ccc; padding: 8px; }
         .truss-popover[hidden] { display: none; }
         #truss-diff-btn[hidden] { display: none; }
         .truss-diff-panel { position: absolute; top: 40px; right: 14px; z-index: 30; background: #fff; border: 1px solid #ccc; padding: 8px; }


### PR DESCRIPTION
The details popover was capped at a flat `280px`. The table menu carrying the
"no export route" note needs **264px** under Playwright's Chromium and **294px**
under Chrome against a byte-identical stylesheet, so the cap sat *inside* the
range two browsers disagree by when measuring the same content. The note
explaining why four items were dimmed scrolled out of sight in one browser and
not the other, and scrolling to reach it pushed the table name out of view.

Reported against the new Lunar demo page on trussphp.com, but `/demo/` clips
identically and always has. It cannot happen in a real installation: with an
export route the note is never added and the menu measures 194px.

## The fix

```
- max-height: 280px;
+ max-height: min(360px, calc(100vh - 16px));
+ max-height: min(360px, calc(100dvh - 16px));
```

Fixing the range rather than the number. The viewport term is not belt and
braces: `placePopover` flips the menu above its anchor when it will not fit
below and pins it to 8px, so it cannot shrink what it is given, and a taller
*flat* cap would trade a clipped menu for one running off the bottom of a short
window. That second failure was real and is covered by a test that failed before
this change by 34px. `dvh` is declared second because on iOS Safari `100vh` is
the toolbars-retracted height.

`min()` carries no fallback deliberately: a browser that cannot parse it drops
the whole declaration, leaving no cap, so nothing clips and the only cost is the
overrun this removes. Benign degradation.

## One cap for four contents, deliberately

`#truss-popover` is the enum list (`truss.js:331`), the table menu (`:376`), the
Export view menu (`:640`) and the column detail (`:980`), so this reaches real
installations and not only the server-less demo. That is a decision rather than
a side effect: the change is monotone, every content shows more before it
scrolls and none shows less, and the only unbounded content is the enum list,
which scrolled at 280 and scrolls later now. Scoping per content would need
`:has()`, which costs more browser floor than the whole fix.

The same note also fills the Export view menu (`truss.js:648`), so the defect
had two entry points. One element and one cap fixes both, and that is now
asserted rather than assumed.

## The harness change is why this could ship at all

`tests/e2e/harness.html` declares a stub `.truss-popover` **after** the injected
stylesheet at equal specificity, so it beat `truss.css` even with `?css=1`. The
shipped popover's box was invisible to the entire e2e suite: a cap too small for
its own content measured correct in there.

`:where()` drops it to `0,0,0`, so it loses whatever the source order is. That
is the reason rather than a smaller diff: moving the injected link would work
only while the order held, and the next person to add a `<style>` would silently
re-mask it.

## Tests

Three, written first and watched fail. They assert **headroom** rather than the
absence of a scrollbar, because the harness renders the menu 30px shorter than
Chrome and a scrollbar check would have passed here while the shipped page
clipped.

Green: **125 Playwright** across chromium and firefox, **150 Vitest**.

## Notes

- **CHANGELOG entry included**, under `[Unreleased]`. The release rule moves
  those into a version section at release time, and `5d07cad` set the precedent
  of an ordinary fix adding one. The version bump is a release step and is not
  here.
- **This does not reach trussphp.com until a release is cut**, because the docs
  site pins its demo assets to the latest release tag.
- Two follow-ups logged privately: the popover specs run on chromium only, so
  the 48px threshold is verified on one engine; and `.truss-zoom` sits in the
  wrong parent in the harness, worked around here with `dispatchEvent` and a
  comment, which is the second time a harness divergence has hidden shipped
  behaviour.
