### PR TITLE
Cover a symlink with the .docs ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,11 @@ composer.lock
 /build/
 /coverage/
 
-# Private/local docs (note: the tracked docs/ folder is NOT ignored)
-/.docs/
+# Private/local docs (note: the tracked docs/ folder is NOT ignored).
+# No trailing slash on purpose: a trailing slash matches directories only, so
+# the entry would not cover a symlink of the same name, and git records a
+# symlink as a file. Without the slash it covers both.
+/.docs
 
 # IDE files
 /.idea/


### PR DESCRIPTION
One character, and the reason for it.

`/.docs/` ends in a slash, which in gitignore matches **directories only**. Git records a symlink as a file rather than a directory, so a path of that name that happens to be a symlink was not covered by the rule and showed up as untracked, one `git add -A` from being committed.

`/.docs` without the slash covers a real directory and a symlink alike, which is what the entry was always meant to do. Verified both cases in a scratch repository rather than assumed.
